### PR TITLE
Made Lanes fetch a new collection when it gets a new url in props.

### DIFF
--- a/packages/opds-web-client/package.json
+++ b/packages/opds-web-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opds-web-client",
-  "version": "0.0.24",
+  "version": "0.0.25",
   "description": "OPDS web client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/packages/opds-web-client/src/components/Lanes.tsx
+++ b/packages/opds-web-client/src/components/Lanes.tsx
@@ -60,6 +60,12 @@ export class Lanes extends React.Component<any, any> {
     }
   }
 
+  componentWillReceiveProps(newProps) {
+    if (this.props.fetchCollection && (newProps.url !== this.props.url)) {
+      this.props.fetchCollection(newProps.url);
+    }
+  }
+
   componentWillUnmount() {
     if (this.props.clearCollection) {
       this.props.clearCollection();

--- a/packages/opds-web-client/src/components/__tests__/Lanes-test.tsx
+++ b/packages/opds-web-client/src/components/__tests__/Lanes-test.tsx
@@ -55,6 +55,25 @@ describe("Lanes", () => {
     expect(fetchCollection.mock.calls[0][0]).toBe(groupedCollectionData.url);
   });
 
+  it("fetches new collection on componentWillReceiveProps if there's a new url", () => {
+    let fetchCollection = jest.genMockFunction();
+    wrapper = shallow(
+      <Lanes
+        url={"test1"}
+        lanes={[]}
+        fetchCollection={fetchCollection}
+        />
+    );
+    expect(fetchCollection.mock.calls.length).toBe(1);
+
+    wrapper.instance().componentWillReceiveProps({url: "test1"});
+    expect(fetchCollection.mock.calls.length).toBe(1);
+
+    wrapper.instance().componentWillReceiveProps({url: "test2"});
+    expect(fetchCollection.mock.calls.length).toBe(2);
+    expect(fetchCollection.mock.calls[1][0]).toBe("test2");
+  });
+
   it("clears collection on unmount", () => {
     let clearCollection = jest.genMockFunction();
     wrapper = shallow(


### PR DESCRIPTION
This fixes https://github.com/NYPL-Simplified/circulation-patron-web/issues/23