### PR TITLE
Clear collection in Lanes component before fetching a new collection

### DIFF
--- a/packages/opds-web-client/src/components/Lanes.tsx
+++ b/packages/opds-web-client/src/components/Lanes.tsx
@@ -61,8 +61,13 @@ export class Lanes extends React.Component<any, any> {
   }
 
   componentWillReceiveProps(newProps) {
-    if (this.props.fetchCollection && (newProps.url !== this.props.url)) {
-      this.props.fetchCollection(newProps.url);
+    if (newProps.url !== this.props.url) {
+      if (this.props.clearCollection) {
+        this.props.clearCollection();
+      }
+      if (this.props.fetchCollection) {
+        this.props.fetchCollection(newProps.url);
+      }
     }
   }
 

--- a/packages/opds-web-client/src/components/__tests__/Lanes-test.tsx
+++ b/packages/opds-web-client/src/components/__tests__/Lanes-test.tsx
@@ -56,20 +56,25 @@ describe("Lanes", () => {
   });
 
   it("fetches new collection on componentWillReceiveProps if there's a new url", () => {
+    let clearCollection = jest.genMockFunction();
     let fetchCollection = jest.genMockFunction();
     wrapper = shallow(
       <Lanes
         url={"test1"}
         lanes={[]}
+        clearCollection={clearCollection}
         fetchCollection={fetchCollection}
         />
     );
+    expect(clearCollection.mock.calls.length).toBe(0);
     expect(fetchCollection.mock.calls.length).toBe(1);
 
     wrapper.instance().componentWillReceiveProps({url: "test1"});
+    expect(clearCollection.mock.calls.length).toBe(0);
     expect(fetchCollection.mock.calls.length).toBe(1);
 
     wrapper.instance().componentWillReceiveProps({url: "test2"});
+    expect(clearCollection.mock.calls.length).toBe(1);
     expect(fetchCollection.mock.calls.length).toBe(2);
     expect(fetchCollection.mock.calls[1][0]).toBe("test2");
   });


### PR DESCRIPTION
This is an addendum to https://github.com/NYPL-Simplified/opds-web-client/pull/151, so that old lanes won't continue to show up while the new collection is being fetched.