### PR TITLE
Cover improvements

### DIFF
--- a/packages/opds-web-client/package.json
+++ b/packages/opds-web-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opds-web-client",
-  "version": "0.0.28",
+  "version": "0.0.29",
   "description": "OPDS web client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/packages/opds-web-client/package.json
+++ b/packages/opds-web-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opds-web-client",
-  "version": "0.0.26",
+  "version": "0.0.27",
   "description": "OPDS web client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/packages/opds-web-client/package.json
+++ b/packages/opds-web-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opds-web-client",
-  "version": "0.0.27",
+  "version": "0.0.28",
   "description": "OPDS web client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/packages/opds-web-client/src/components/Book.tsx
+++ b/packages/opds-web-client/src/components/Book.tsx
@@ -20,13 +20,6 @@ export default class Book extends React.Component<BookProps, any> {
       textAlign: "center"
     };
 
-    let bookCoverStyle = {
-      width: "150px",
-      height: "200px",
-      float: "left",
-      border: "1px solid #ccc"
-    };
-
     let bookInfoStyle = {
       width: "160px",
       textAlign: "left",
@@ -51,10 +44,7 @@ export default class Book extends React.Component<BookProps, any> {
           collectionUrl={this.props.collectionUrl}
           bookUrl={this.props.book.url || this.props.book.id}
           style={{ color: "black", textDecoration: "none" }}>
-          { this.props.book.imageUrl ?
-            <img src={this.props.book.imageUrl} style={bookCoverStyle} alt=""/> :
-            <BookCover book={this.props.book} />
-          }
+          <BookCover book={this.props.book} />
         </CatalogLink>
         <div className="bookInfo" style={ bookInfoStyle }>
           <CatalogLink

--- a/packages/opds-web-client/src/components/BookCover.tsx
+++ b/packages/opds-web-client/src/components/BookCover.tsx
@@ -8,7 +8,35 @@ export interface BookCoverProps extends React.HTMLProps<BookCover> {
 }
 
 export default class BookCover extends React.Component<BookCoverProps, any> {
+  constructor(props) {
+    super(props);
+    this.state = { error: false };
+    this.handleError = this.handleError.bind(this);
+  }
+
+  handleError(event) {
+    this.setState({ error: true });
+  }
+
   render() {
+    let bookCoverStyle = {
+      width: "150px",
+      height: "200px",
+      float: "left",
+      border: "1px solid #ccc"
+    };
+
+    if (this.props.book.imageUrl && !this.state.error) {
+      return (
+        <img
+          src={this.props.book.imageUrl}
+          onError={this.handleError}
+          style={bookCoverStyle}
+          alt=""
+          />
+      );
+    }
+
     let { title, authors } = this.props.book;
 
     let titleStyle = Object.assign({

--- a/packages/opds-web-client/src/components/BookCover.tsx
+++ b/packages/opds-web-client/src/components/BookCover.tsx
@@ -18,6 +18,12 @@ export default class BookCover extends React.Component<BookCoverProps, any> {
     this.setState({ error: true });
   }
 
+  componentWillReceiveProps(nextProps) {
+    if (this.state.error) {
+      this.setState({ error: false });
+    }
+  }
+
   render() {
     let bookCoverStyle = {
       width: "150px",

--- a/packages/opds-web-client/src/components/BookDetails.tsx
+++ b/packages/opds-web-client/src/components/BookDetails.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import CatalogLink from "./CatalogLink";
 import BorrowButton from "./BorrowButton";
 import DownloadButton from "./DownloadButton";
+import BookCover from "./BookCover";
 import { BookProps } from "./Book";
 import { BookData } from "../interfaces";
 const download = require("downloadjs");
@@ -30,11 +31,9 @@ export default class BookDetails<P extends BookDetailsProps> extends React.Compo
     return (
       <div className="bookDetails">
         <div className="bookDetailsTop" style={{ textAlign: "left", display: "table-row" }}>
-          { this.props.book.imageUrl &&
-            <div className="bookImage" style={{ display: "table-cell", paddingRight: "20px", verticalAlign: "top" }}>
-              <img src={this.props.book.imageUrl} style={{ height: "150px" }}/>
-            </div>
-          }
+          <div className="bookImage" style={{ display: "table-cell", paddingRight: "20px", verticalAlign: "top" }}>
+            <BookCover book={this.props.book} />
+          </div>
           <div className="bookDetailsHeader" style={{ display: "table-cell", verticalAlign: "top", textAlign: "left", maxWidth: "500px" }}>
             <h1 className="bookDetailsTitle" style={{ margin: 0 }}>{this.props.book.title}</h1>
             {

--- a/packages/opds-web-client/src/components/LaneBook.tsx
+++ b/packages/opds-web-client/src/components/LaneBook.tsx
@@ -12,12 +12,6 @@ export default class LaneBook extends Book {
       height: "250px"
     };
 
-    let bookCoverStyle = {
-      width: "150px",
-      height: "200px",
-      border: "1px solid #ccc"
-    };
-
     let bookInfoStyle = {
       clear: "left",
       width: "150px",
@@ -32,10 +26,7 @@ export default class LaneBook extends Book {
           collectionUrl={this.props.collectionUrl}
           bookUrl={this.props.book.url}
           style={{ color: "black", textDecoration: "none" }}>
-          { this.props.book.imageUrl ?
-            <img src={this.props.book.imageUrl} style={bookCoverStyle} alt=""/> :
-            <BookCover book={this.props.book} />
-          }
+          <BookCover book={this.props.book} />
           <div className="bookInfo" style={ bookInfoStyle }>
             <div className="bookTitle">{this.props.book.title}</div>
           </div>

--- a/packages/opds-web-client/src/components/__tests__/Book-test.tsx
+++ b/packages/opds-web-client/src/components/__tests__/Book-test.tsx
@@ -6,6 +6,7 @@ import { shallow } from "enzyme";
 import Book from "../Book";
 import { BookData } from "../../interfaces";
 import CatalogLink from "../CatalogLink";
+import BookCover from "../BookCover";
 
 let book: BookData = {
   id: "urn:librarysimplified.org/terms/id/3M%20ID/crrmnr9",
@@ -18,17 +19,16 @@ let book: BookData = {
 };
 
 describe("Book", () => {
-  it("shows the book cover with empty alt", () => {
+  it("shows the book cover", () => {
     let wrapper = shallow(
       <Book book={book} />
     );
 
     let links = wrapper.find(CatalogLink);
     expect(links.length).toEqual(2);
-    let coverImage = links.at(0).children().at(0);
-    expect(coverImage.type()).toBe("img");
-    expect(coverImage.props().src).toBe(book.imageUrl);
-    expect(coverImage.props().alt).toBe("");
+    let cover = links.at(0).children().at(0);
+    expect(cover.type()).toBe(BookCover);
+    expect(cover.props().book).toBe(book);
   });
 
   it("shows book info", () => {

--- a/packages/opds-web-client/src/components/__tests__/BookCover-test.tsx
+++ b/packages/opds-web-client/src/components/__tests__/BookCover-test.tsx
@@ -59,6 +59,15 @@ describe("BookCover", () => {
 
       let authors = wrapper.childAt(1);
       expect(authors.text()).toBe(bookData.authors.join(", "));
+
+      // The placeholder is cleared when there are new props.
+      let newBookData = {
+        id: "new book",
+        imageUrl: "https://dlotdqc6pnwqb.cloudfront.net/3M/abcdefg/cover.jpg"
+      };
+      wrapper.setProps({ book: newBookData });
+      image = wrapper.find("img");
+      expect(image.props().src).toBe(newBookData.imageUrl);
     });
   });
 });

--- a/packages/opds-web-client/src/components/__tests__/BookCover-test.tsx
+++ b/packages/opds-web-client/src/components/__tests__/BookCover-test.tsx
@@ -6,24 +6,59 @@ import { shallow } from "enzyme";
 import BookCover from "../BookCover";
 
 describe("BookCover", () => {
-  let wrapper;
-  let bookData = {
-    id: "test id",
-    title: "test book",
-    authors: ["paperback writer", "brilliant recluse"]
-  };
+  describe("with no image url", () => {
+    let wrapper;
+    let bookData = {
+      id: "test id",
+      title: "test book",
+      authors: ["paperback writer", "brilliant recluse"]
+    };
 
-  beforeEach(() => {
-    wrapper = shallow(
-      <BookCover book={bookData} />
-    );
+    beforeEach(() => {
+      wrapper = shallow(
+        <BookCover book={bookData} />
+      );
+    });
+
+    it("shows title and authors", () => {
+      let title = wrapper.childAt(0);
+      expect(title.text()).toBe(bookData.title);
+
+      let authors = wrapper.childAt(1);
+      expect(authors.text()).toBe(bookData.authors.join(", "));
+    });
   });
 
-  it("shows title and authors", () => {
-    let title = wrapper.childAt(0);
-    expect(title.text()).toBe(bookData.title);
+  describe("with image url", () => {
+    let wrapper;
+    let bookData = {
+      id: "test id",
+      title: "test book",
+      authors: ["paperback writer", "brilliant recluse"],
+      imageUrl: "https://dlotdqc6pnwqb.cloudfront.net/3M/crrmnr9/cover.jpg"
+    };
 
-    let authors = wrapper.childAt(1);
-    expect(authors.text()).toBe(bookData.authors.join(", "));
+    beforeEach(() => {
+      wrapper = shallow(
+        <BookCover book={bookData} />
+      );
+    });
+
+    it("shows the book cover with empty alt", () => {
+      let image = wrapper.find("img");
+      expect(image.props().src).toBe(bookData.imageUrl);
+      expect(image.props().alt).toBe("");
+    });
+
+    it("shows the placeholder cover on image error", () => {
+      let image = wrapper.find("img");
+      image.simulate("error");
+
+      let title = wrapper.childAt(0);
+      expect(title.text()).toBe(bookData.title);
+
+      let authors = wrapper.childAt(1);
+      expect(authors.text()).toBe(bookData.authors.join(", "));
+    });
   });
 });

--- a/packages/opds-web-client/src/components/__tests__/BookDetails-test.tsx
+++ b/packages/opds-web-client/src/components/__tests__/BookDetails-test.tsx
@@ -4,6 +4,7 @@ import * as React from "react";
 import { shallow } from "enzyme";
 
 import BookDetails from "../BookDetails";
+import BookCover from "../BookCover";
 import BorrowButton from "../BorrowButton";
 import DownloadButton from "../DownloadButton";
 
@@ -37,8 +38,8 @@ describe("BookDetails", () => {
   });
 
   it("shows cover", () => {
-    let coverImage = wrapper.find("img");
-    expect(coverImage.props().src).toBe(book.imageUrl);
+    let cover = wrapper.find(BookCover);
+    expect(cover.props().book).toBe(book);
   });
 
   it("shows title", () => {

--- a/packages/opds-web-client/src/components/__tests__/LaneBook-test.tsx
+++ b/packages/opds-web-client/src/components/__tests__/LaneBook-test.tsx
@@ -6,6 +6,7 @@ import { shallow } from "enzyme";
 import LaneBook from "../LaneBook";
 import { BookProps } from "../Book";
 import CatalogLink, { CatalogLinkProps } from "../CatalogLink";
+import BookCover from "../BookCover";
 import { BookData } from "../../interfaces";
 
 let book: BookData = {
@@ -18,14 +19,13 @@ let book: BookData = {
 };
 
 describe("LaneBook", () => {
-  it("shows the book cover with empty alt", () => {
+  it("shows the book cover", () => {
     let wrapper = shallow(
       <LaneBook book={book} />
     );
 
-    let coverImage = wrapper.find("img");
-    expect(coverImage.props().src).toBe(book.imageUrl);
-    expect(coverImage.props().alt).toEqual("");
+    let cover = wrapper.find(BookCover);
+    expect(cover.props().book).toBe(book);
   });
 
   it("shows book title in a CatalogLink", () => {


### PR DESCRIPTION
A couple small changes for https://github.com/NYPL-Simplified/opds-web-client/issues/149

I moved all the code to handle showing an image or a placeholder to the BookCover component, and it's used in the collection as well as the book details page. The BookCover component also handles 404s now.