### PR TITLE
Update book action

### DIFF
--- a/packages/opds-web-client/package.json
+++ b/packages/opds-web-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opds-web-client",
-  "version": "0.0.33",
+  "version": "0.0.34",
   "description": "OPDS web client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/packages/opds-web-client/src/__tests__/actions-test.ts
+++ b/packages/opds-web-client/src/__tests__/actions-test.ts
@@ -123,7 +123,7 @@ describe("actions", () => {
     });
   });
 
-  describe("borrowBook", () => {
+  describe("updateBook", () => {
     let borrowUrl = "http://example.com/book/borrow";
     let fulfillmentUrl = "http://example.com/book/fulfill";
     let mimeType = "mime/type";
@@ -133,11 +133,11 @@ describe("actions", () => {
       fetcher.resolve = true;
       fetcher.testData = { fulfillmentUrl, mimeType };
 
-      actions.borrowBook(borrowUrl)(dispatch).then(data => {
+      actions.updateBook(borrowUrl)(dispatch).then(data => {
         expect(dispatch.mock.calls.length).toBe(3);
-        expect(dispatch.mock.calls[0][0].type).toBe(actions.BORROW_BOOK_REQUEST);
-        expect(dispatch.mock.calls[1][0].type).toBe(actions.BORROW_BOOK_SUCCESS);
-        expect(dispatch.mock.calls[2][0].type).toBe(actions.LOAD_BORROW_DATA);
+        expect(dispatch.mock.calls[0][0].type).toBe(actions.UPDATE_BOOK_REQUEST);
+        expect(dispatch.mock.calls[1][0].type).toBe(actions.UPDATE_BOOK_SUCCESS);
+        expect(dispatch.mock.calls[2][0].type).toBe(actions.LOAD_UPDATE_BOOK_DATA);
         expect(data).toEqual(fetcher.testData);
         done();
       }).catch(done.fail);
@@ -147,10 +147,10 @@ describe("actions", () => {
       let dispatch = jest.genMockFunction();
       fetcher.resolve = false;
 
-      actions.borrowBook(borrowUrl)(dispatch).catch(err => {
+      actions.updateBook(borrowUrl)(dispatch).catch(err => {
         expect(dispatch.mock.calls.length).toBe(2);
-        expect(dispatch.mock.calls[0][0].type).toBe(actions.BORROW_BOOK_REQUEST);
-        expect(dispatch.mock.calls[1][0].type).toBe(actions.BORROW_BOOK_FAILURE);
+        expect(dispatch.mock.calls[0][0].type).toBe(actions.UPDATE_BOOK_REQUEST);
+        expect(dispatch.mock.calls[1][0].type).toBe(actions.UPDATE_BOOK_FAILURE);
         expect(err).toBe("test error");
         done();
       });

--- a/packages/opds-web-client/src/actions.ts
+++ b/packages/opds-web-client/src/actions.ts
@@ -33,10 +33,10 @@ export default class ActionCreator {
   LOAD_SEARCH_DESCRIPTION = "LOAD_SEARCH_DESCRIPTION";
   CLOSE_ERROR = "CLOSE_ERROR";
 
-  BORROW_BOOK_REQUEST = "BORROW_BOOK_REQUEST";
-  BORROW_BOOK_SUCCESS = "BORROW_BOOK_SUCCESS";
-  BORROW_BOOK_FAILURE = "BORROW_BOOK_FAILURE";
-  LOAD_BORROW_DATA = "LOAD_BORROW_DATA";
+  UPDATE_BOOK_REQUEST = "UPDATE_BOOK_REQUEST";
+  UPDATE_BOOK_SUCCESS = "UPDATE_BOOK_SUCCESS";
+  UPDATE_BOOK_FAILURE = "UPDATE_BOOK_FAILURE";
+  LOAD_UPDATE_BOOK_DATA = "LOAD_UPDATE_BOOK_DATA";
 
   FULFILL_BOOK_REQUEST = "FULFILL_BOOK_REQUEST";
   FULFILL_BOOK_SUCCESS = "FULFILL_BOOK_SUCCESS";
@@ -179,36 +179,36 @@ export default class ActionCreator {
     return { type: this.CLEAR_BOOK };
   }
 
-  borrowBook(url: string): (dispatch: any) => Promise<BookData> {
+  updateBook(url: string): (dispatch: any) => Promise<BookData> {
     return (dispatch) => {
-      dispatch(this.borrowBookRequest());
+      dispatch(this.updateBookRequest());
       return new Promise((resolve, reject) => {
         this.fetcher.fetchOPDSData(url).then((data: BookData) => {
-          dispatch(this.borrowBookSuccess());
-          dispatch(this.loadBorrowData(data));
+          dispatch(this.updateBookSuccess());
+          dispatch(this.loadUpdateBookData(data));
           resolve(data);
         }).catch((err: FetchErrorData) => {
-          dispatch(this.borrowBookFailure(err));
+          dispatch(this.updateBookFailure(err));
           reject(err);
         });
       });
     };
   }
 
-  borrowBookRequest() {
-    return { type: this.BORROW_BOOK_REQUEST };
+  updateBookRequest() {
+    return { type: this.UPDATE_BOOK_REQUEST };
   }
 
-  borrowBookSuccess() {
-    return { type: this.BORROW_BOOK_SUCCESS };
+  updateBookSuccess() {
+    return { type: this.UPDATE_BOOK_SUCCESS };
   }
 
-  borrowBookFailure(error) {
-    return { type: this.BORROW_BOOK_FAILURE, error };
+  updateBookFailure(error) {
+    return { type: this.UPDATE_BOOK_FAILURE, error };
   }
 
-  loadBorrowData(data) {
-    return { type: this.LOAD_BORROW_DATA, data };
+  loadUpdateBookData(data) {
+    return { type: this.LOAD_UPDATE_BOOK_DATA, data };
   }
 
   fulfillBook(url: string): (dispatch: any) => Promise<Blob> {

--- a/packages/opds-web-client/src/components/BookDetails.tsx
+++ b/packages/opds-web-client/src/components/BookDetails.tsx
@@ -9,7 +9,7 @@ import { BookData } from "../interfaces";
 const download = require("downloadjs");
 
 export interface BookDetailsProps extends BookProps {
-  borrowBook: (url: string) => Promise<BookData>;
+  updateBook: (url: string) => Promise<BookData>;
   fulfillBook: (url: string) => Promise<Blob>;
   indirectFulfillBook: (url: string, type: string) => Promise<string>;
   isSignedIn?: boolean;
@@ -241,7 +241,7 @@ export default class BookDetails<P extends BookDetailsProps> extends React.Compo
   }
 
   borrow(): Promise<BookData> {
-    return this.props.borrowBook(this.props.book.borrowUrl);
+    return this.props.updateBook(this.props.book.borrowUrl);
   }
 
   isReserved() {

--- a/packages/opds-web-client/src/components/Root.tsx
+++ b/packages/opds-web-client/src/components/Root.tsx
@@ -63,7 +63,7 @@ export interface RootProps extends StateProps {
   Footer?: new() => __React.Component<FooterProps, any>;
   BookDetailsContainer?: new() =>  __React.Component<BookDetailsContainerProps, any>;
   computeBreadcrumbs?: ComputeBreadcrumbs;
-  borrowBook?: (url: string) => Promise<BookData>;
+  updateBook?: (url: string) => Promise<BookData>;
   fulfillBook?: (url: string) => Promise<Blob>;
   indirectFulfillBook?: (url: string, type: string) => Promise<string>;
   fetchLoans?: (url: string) => Promise<any>;
@@ -240,7 +240,7 @@ export class Root extends React.Component<RootProps, any> {
                     >
                     <BookDetails
                       book={this.loanedBookData() || this.props.bookData}
-                      borrowBook={this.props.borrowBook}
+                      updateBook={this.props.updateBook}
                       fulfillBook={this.props.fulfillBook}
                       indirectFulfillBook={this.props.indirectFulfillBook}
                       isSignedIn={this.props.isSignedIn}
@@ -249,7 +249,7 @@ export class Root extends React.Component<RootProps, any> {
                   <div style={{ padding: "40px", maxWidth: "700px", margin: "0 auto" }}>
                     <BookDetails
                       book={this.loanedBookData() || this.props.bookData}
-                      borrowBook={this.props.borrowBook}
+                      updateBook={this.props.updateBook}
                       fulfillBook={this.props.fulfillBook}
                       indirectFulfillBook={this.props.indirectFulfillBook}
                       isSignedIn={this.props.isSignedIn}

--- a/packages/opds-web-client/src/components/__tests__/BookDetails-test.tsx
+++ b/packages/opds-web-client/src/components/__tests__/BookDetails-test.tsx
@@ -34,7 +34,7 @@ describe("BookDetails", () => {
     wrapper = shallow(
       <BookDetails
         book={book}
-        borrowBook={jest.genMockFunction()}
+        updateBook={jest.genMockFunction()}
         fulfillBook={jest.genMockFunction()}
         indirectFulfillBook={jest.genMockFunction()}
         />
@@ -78,7 +78,7 @@ describe("BookDetails", () => {
     wrapper = shallow(
       <BookDetails
         book={bookCopy}
-        borrowBook={jest.genMockFunction()}
+        updateBook={jest.genMockFunction()}
         fulfillBook={jest.genMockFunction()}
         indirectFulfillBook={jest.genMockFunction()}
         />
@@ -103,7 +103,7 @@ describe("BookDetails", () => {
     wrapper = shallow(
       <BookDetails
         book={bookCopy}
-        borrowBook={jest.genMockFunction()}
+        updateBook={jest.genMockFunction()}
         fulfillBook={jest.genMockFunction()}
         indirectFulfillBook={jest.genMockFunction()}
         />
@@ -129,11 +129,11 @@ describe("BookDetails", () => {
     let bookCopy = Object.assign({}, book, {
       borrowUrl: "borrow url"
     });
-    let borrowBook = jest.genMockFunction();
+    let updateBook = jest.genMockFunction();
     wrapper = shallow(
       <BookDetails
         book={bookCopy}
-        borrowBook={borrowBook}
+        updateBook={updateBook}
         fulfillBook={jest.genMockFunction()}
         indirectFulfillBook={jest.genMockFunction()}
         />
@@ -142,8 +142,8 @@ describe("BookDetails", () => {
     let button = wrapper.find(BorrowButton);
     expect(button.children().text()).toBe("Borrow");
     button.props().borrow();
-    expect(borrowBook.mock.calls.length).toBe(1);
-    expect(borrowBook.mock.calls[0][0]).toBe(bookCopy.borrowUrl);
+    expect(updateBook.mock.calls.length).toBe(1);
+    expect(updateBook.mock.calls[0][0]).toBe(bookCopy.borrowUrl);
     wrapper.setProps({
       book: Object.assign({}, bookCopy, {
         copies: { total: 2, available: 0 }
@@ -164,7 +164,7 @@ describe("BookDetails", () => {
     wrapper = shallow(
       <BookDetails
         book={bookCopy}
-        borrowBook={jest.genMockFunction()}
+        updateBook={jest.genMockFunction()}
         fulfillBook={fulfillBook}
         indirectFulfillBook={indirectFulfillBook}
         isSignedIn={false}
@@ -187,7 +187,7 @@ describe("BookDetails", () => {
     wrapper = shallow(
       <BookDetails
         book={bookCopy}
-        borrowBook={jest.genMockFunction()}
+        updateBook={jest.genMockFunction()}
         fulfillBook={jest.genMockFunction()}
         indirectFulfillBook={jest.genMockFunction()}
         />
@@ -211,7 +211,7 @@ describe("BookDetails", () => {
     wrapper = shallow(
       <BookDetails
         book={bookCopy}
-        borrowBook={jest.genMockFunction()}
+        updateBook={jest.genMockFunction()}
         fulfillBook={jest.genMockFunction()}
         indirectFulfillBook={jest.genMockFunction()}
         />
@@ -235,7 +235,7 @@ describe("BookDetails", () => {
     wrapper = shallow(
       <BookDetails
         book={bookCopy}
-        borrowBook={jest.genMockFunction()}
+        updateBook={jest.genMockFunction()}
         fulfillBook={jest.genMockFunction()}
         indirectFulfillBook={jest.genMockFunction()}
         />
@@ -260,7 +260,7 @@ describe("BookDetails", () => {
     wrapper = shallow(
       <BookDetails
         book={bookCopy}
-        borrowBook={jest.genMockFunction()}
+        updateBook={jest.genMockFunction()}
         fulfillBook={jest.genMockFunction()}
         indirectFulfillBook={jest.genMockFunction()}
         />
@@ -285,7 +285,7 @@ describe("BookDetails", () => {
     wrapper = shallow(
       <BookDetails
         book={bookCopy}
-        borrowBook={jest.genMockFunction()}
+        updateBook={jest.genMockFunction()}
         fulfillBook={jest.genMockFunction()}
         indirectFulfillBook={jest.genMockFunction()}
         />

--- a/packages/opds-web-client/src/components/__tests__/Root-test.tsx
+++ b/packages/opds-web-client/src/components/__tests__/Root-test.tsx
@@ -250,14 +250,14 @@ describe("Root", () => {
     let loans = [Object.assign({}, bookData, {
       availability: { status: "availabile" }
     })];
-    let borrowBook = jest.genMockFunction();
+    let updateBook = jest.genMockFunction();
     let fulfillBook = jest.genMockFunction();
     let indirectFulfillBook = jest.genMockFunction();
     let wrapper = shallow(
       <Root
         bookData={bookData}
         loans={loans}
-        borrowBook={borrowBook}
+        updateBook={updateBook}
         fulfillBook={fulfillBook}
         indirectFulfillBook={indirectFulfillBook}
         isSignedIn={true}
@@ -269,7 +269,7 @@ describe("Root", () => {
 
     expect(bookWrapper.length).toBe(1);
     expect(book.props().book).toEqual(loans[0]);
-    expect(book.props().borrowBook).toBe(borrowBook);
+    expect(book.props().updateBook).toBe(updateBook);
     expect(book.props().fulfillBook).toBe(fulfillBook);
     expect(book.props().indirectFulfillBook).toBe(indirectFulfillBook);
     expect(book.props().isSignedIn).toBe(true);
@@ -328,7 +328,7 @@ describe("Root", () => {
     it("renders BookDetailsContainer with urls, refresh, and book details", () => {
       let bookData = groupedCollectionData.lanes[0].books[0];
       let refresh = jest.genMockFunction();
-      let borrowBook = jest.genMockFunction();
+      let updateBook = jest.genMockFunction();
       let fulfillBook = jest.genMockFunction();
       let wrapper = shallow(
         <Root
@@ -338,7 +338,7 @@ describe("Root", () => {
           refreshCollectionAndBook={refresh}
           setCollectionAndBook={mockSetCollectionAndBook}
           BookDetailsContainer={Container}
-          borrowBook={borrowBook}
+          updateBook={updateBook}
           fulfillBook={fulfillBook}
           />
       );

--- a/packages/opds-web-client/src/components/__tests__/mergeRootProps-test.ts
+++ b/packages/opds-web-client/src/components/__tests__/mergeRootProps-test.ts
@@ -65,7 +65,7 @@ describe("createFetchCollectionAndBook", () => {
 
 describe("mergeRootProps", () => {
   let stateProps, dispatchProps, componentProps;
-  let fetchCollection, clearCollection, fetchBook, loadBook, clearBook, navigate, borrowBook, fetchLoans;
+  let fetchCollection, clearCollection, fetchBook, loadBook, clearBook, navigate, updateBook, fetchLoans;
   let fakeCollection = ungroupedCollectionData;
   let fakeBook = {
     id: "fake book id",
@@ -87,14 +87,14 @@ describe("mergeRootProps", () => {
     loadBook = jest.genMockFunction();
     clearCollection = jest.genMockFunction();
     clearBook = jest.genMockFunction();
-    borrowBook = jest.genMockFunction().mockImplementation(url => {
+    updateBook = jest.genMockFunction().mockImplementation(url => {
       return new Promise((resolve, reject) => resolve(fakeBook));
     });
     fetchLoans = jest.genMockFunction();
     dispatchProps = { createDispatchProps: (fetcher) => {
       return {
         fetchCollection, clearCollection, loadBook, fetchBook, clearBook,
-        borrowBook, fetchLoans
+        updateBook, fetchLoans
       };
     }};
     componentProps = {};
@@ -444,18 +444,18 @@ describe("mergeRootProps", () => {
     });
   });
 
-  describe("borrowBook", () => {
+  describe("updateBook", () => {
     let props;
 
-    it("calls borrowBook", () => {
+    it("calls updateBook", () => {
       stateProps = {
         loansUrl: "loans"
       };
       props = mergeRootProps(stateProps, dispatchProps, componentProps);
-      props.borrowBook("borrow url");
+      props.updateBook("borrow url");
 
-      expect(borrowBook.mock.calls.length).toBe(1);
-      expect(borrowBook.mock.calls[0][0]).toBe("borrow url");
+      expect(updateBook.mock.calls.length).toBe(1);
+      expect(updateBook.mock.calls[0][0]).toBe("borrow url");
     });
 
     it("calls fetchLoans if loansUrl is present", (done) => {
@@ -464,7 +464,7 @@ describe("mergeRootProps", () => {
       };
       props = mergeRootProps(stateProps, dispatchProps, componentProps);
 
-      props.borrowBook().then(data => {
+      props.updateBook().then(data => {
         expect(fetchLoans.mock.calls.length).toBe(1);
         expect(fetchLoans.mock.calls[0][0]).toBe("loans");
         expect(data).toEqual(fakeBook);
@@ -475,7 +475,7 @@ describe("mergeRootProps", () => {
     it("doesn't call fetchLoans if loansUrl is blank", (done) => {
       props = mergeRootProps({}, dispatchProps, componentProps);
 
-      props.borrowBook().then(data => {
+      props.updateBook().then(data => {
         expect(fetchLoans.mock.calls.length).toBe(0);
         done();
       }).catch(done.fail);

--- a/packages/opds-web-client/src/components/mergeRootProps.ts
+++ b/packages/opds-web-client/src/components/mergeRootProps.ts
@@ -48,7 +48,7 @@ export function mapDispatchToProps(dispatch) {
         clearBook: () => dispatch(actions.clearBook()),
         fetchSearchDescription: (url: string) => dispatch(actions.fetchSearchDescription(url)),
         closeError: () => dispatch(actions.closeError()),
-        borrowBook: (url: string) => dispatch(actions.borrowBook(url)),
+        updateBook: (url: string) => dispatch(actions.updateBook(url)),
         fulfillBook: (url: string) => dispatch(actions.fulfillBook(url)),
         indirectFulfillBook: (url: string, type: string) => dispatch(actions.indirectFulfillBook(url, type)),
         fetchLoans: (url: string) => dispatch(actions.fetchLoans(url)),
@@ -166,8 +166,8 @@ export function mergeRootProps(stateProps, createDispatchProps, componentProps) 
 
   let { fetchCollection, fetchBook } = dispatchProps;
 
-  let borrowBook = (url: string) => {
-    return dispatchProps.borrowBook(url).then((data) => {
+  let updateBook = (url: string) => {
+    return dispatchProps.updateBook(url).then((data) => {
       if (stateProps.loansUrl) {
         dispatchProps.fetchLoans(stateProps.loansUrl);
       }
@@ -203,6 +203,6 @@ export function mergeRootProps(stateProps, createDispatchProps, componentProps) 
     clearBook: () => {
       setBook(null);
     },
-    borrowBook: borrowBook
+    updateBook: updateBook
   });
 };

--- a/packages/opds-web-client/src/reducers/__tests__/loans-test.ts
+++ b/packages/opds-web-client/src/reducers/__tests__/loans-test.ts
@@ -64,4 +64,21 @@ describe("loans reducer", () => {
 
     expect(reducer(oldState, action)).toEqual(newState);
   });
+
+  it("clears books on LOAD_UPDATE_BOOK_DATA", () => {
+    let oldState = Object.assign({}, initState, {
+        books: loansData
+    });
+    let newBookData = {
+      id: "book id",
+      url: "book url",
+      title: "new book title"
+    };
+    let action = actions.loadUpdateBookData(newBookData);
+    let newState = Object.assign({}, oldState, {
+      books: []
+    });
+
+    expect(reducer(oldState, action)).toEqual(newState);
+  });
 });

--- a/packages/opds-web-client/src/reducers/book.ts
+++ b/packages/opds-web-client/src/reducers/book.ts
@@ -48,25 +48,25 @@ const book = (state: BookState = initialState, action): BookState => {
       });
 
     case "FULFILL_BOOK_REQUEST":
-    case "BORROW_BOOK_REQUEST":
+    case "UPDATE_BOOK_REQUEST":
       return Object.assign({}, state, {
         isFetching: true
       });
 
     case "FULFILL_BOOK_SUCCESS":
-    case "BORROW_BOOK_SUCCESS":
+    case "UPDATE_BOOK_SUCCESS":
       return Object.assign({}, state, {
         isFetching: false
       });
 
     case "FULFILL_BOOK_FAILURE":
-    case "BORROW_BOOK_FAILURE":
+    case "UPDATE_BOOK_FAILURE":
       return Object.assign({}, state, {
         isFetching: false,
         error: action.error
       });
 
-    case "LOAD_BORROW_DATA":
+    case "LOAD_UPDATE_BOOK_DATA":
       return Object.assign({}, state, {
         data: Object.assign({}, state.data, action.data)
       });

--- a/packages/opds-web-client/src/reducers/loans.ts
+++ b/packages/opds-web-client/src/reducers/loans.ts
@@ -26,6 +26,16 @@ export default (state: LoansState = initialState, action): LoansState => {
         books: action.books
       });
 
+    case "LOAD_UPDATE_BOOK_DATA":
+      // A book has been updated, so the loans feed is now outdated.
+      // If we remove the loans, the components showing the book that
+      // was updated can use the data from the book update request 
+      // until the next LOAD_LOANS action.
+
+      return Object.assign({}, state, {
+        books: []
+      });
+
     default:
       return state;
   }


### PR DESCRIPTION
To implement revoke in circulation-patron-web, I need a way to make an authenticated request to the revoke url and process the OPDS entry. I realized the borrow code doesn't actually do anything specific to borrowing, so I changed the action to be more general. You can pass in any url that returns an OPDS entry, optionally after updating a book. This way I can use it for revoke without having to pass any additional props around.