### PR TITLE
Multiple auth providers

### DIFF
--- a/packages/opds-web-client/package.json
+++ b/packages/opds-web-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opds-web-client",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "OPDS web client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/packages/opds-web-client/src/AuthPlugin.ts
+++ b/packages/opds-web-client/src/AuthPlugin.ts
@@ -1,0 +1,10 @@
+import { AuthFormProps, AuthButtonProps } from "./components/AuthProviderSelectionForm";
+
+interface AuthPlugin {
+  type: string;
+  lookForCredentials: () => void;
+  formComponent: new(props: AuthFormProps) => __React.Component<AuthFormProps, any>;
+  buttonComponent: new(props: AuthButtonProps) => __React.Component<AuthButtonProps, any>;
+}
+
+export default AuthPlugin;

--- a/packages/opds-web-client/src/AuthPlugin.ts
+++ b/packages/opds-web-client/src/AuthPlugin.ts
@@ -1,10 +1,11 @@
 import { AuthFormProps, AuthButtonProps } from "./components/AuthProviderSelectionForm";
+import { AuthMethod } from "./interfaces";
 
 interface AuthPlugin {
   type: string;
   lookForCredentials: () => void;
-  formComponent: new(props: AuthFormProps) => __React.Component<AuthFormProps, any>;
-  buttonComponent: new(props: AuthButtonProps) => __React.Component<AuthButtonProps, any>;
+  formComponent: new(props: AuthFormProps<AuthMethod>) => __React.Component<AuthFormProps<AuthMethod>, any>;
+  buttonComponent: new(props: AuthButtonProps<AuthMethod>) => __React.Component<AuthButtonProps<AuthMethod>, any>;
 }
 
 export default AuthPlugin;

--- a/packages/opds-web-client/src/BasicAuthPlugin.ts
+++ b/packages/opds-web-client/src/BasicAuthPlugin.ts
@@ -1,0 +1,14 @@
+import AuthPlugin from "./AuthPlugin";
+import BasicAuthForm from "./components/BasicAuthForm";
+import BasicAuthButton from "./components/BasicAuthButton";
+
+const BasicAuthPlugin: AuthPlugin = {
+  type: "http://opds-spec.org/auth/basic",
+
+  lookForCredentials: () => {},
+
+  formComponent: BasicAuthForm,
+  buttonComponent: BasicAuthButton
+};
+
+export default BasicAuthPlugin;

--- a/packages/opds-web-client/src/__mocks__/DataFetcher.ts
+++ b/packages/opds-web-client/src/__mocks__/DataFetcher.ts
@@ -24,10 +24,10 @@ export default class MockDataFetcher extends DataFetcher {
     });
   }
 
-  getBasicAuthCredentials() {
-    return "credentials";
+  getAuthCredentials() {
+    return { provider: "test", credentials: "credentials" };
   }
 };
 
-MockDataFetcher.prototype.setBasicAuthCredentials = stub();
-MockDataFetcher.prototype.clearBasicAuthCredentials = stub();
+MockDataFetcher.prototype.setAuthCredentials = stub();
+MockDataFetcher.prototype.clearAuthCredentials = stub();

--- a/packages/opds-web-client/src/__tests__/DataFetcher-test.ts
+++ b/packages/opds-web-client/src/__tests__/DataFetcher-test.ts
@@ -76,30 +76,34 @@ describe("DataFetcher", () => {
     expect(mockFetch.args[0][1].body.get("url").value).to.equal("test url");
   });
 
-  it("prepares basic auth headers", () => {
+  it("prepares auth headers", () => {
     let fetcher = new DataFetcher();
-    fetcher.getBasicAuthCredentials = () => "credentials";
+    let credentials = { provider: "test", credentials: "credentials" };
+    fetcher.getAuthCredentials = () => credentials;
     fetcher.fetch("test url");
-    expect(mockFetch.args[0][1].headers["Authorization"]).to.equal("Basic credentials");
+    expect(mockFetch.args[0][1].headers["Authorization"]).to.equal("credentials");
   });
 
-  it("sets basic auth credentials", () => {
+  it("sets auth credentials", () => {
     let fetcher = new DataFetcher();
-    fetcher.setBasicAuthCredentials("credentials");
-    expect(Cookie.get(fetcher.basicAuthKey)).to.equal("credentials");
+    let credentials = { provider: "test", credentials: "credentials" };
+    fetcher.setAuthCredentials(credentials);
+    expect(Cookie.get(fetcher.authKey)).to.deep.equal(JSON.stringify(credentials));
   });
 
-  it("gets basic auth credentials", () => {
+  it("gets auth credentials", () => {
     let fetcher = new DataFetcher();
-    Cookie.set(fetcher.basicAuthKey, "credentials");
-    expect(fetcher.getBasicAuthCredentials()).to.equal("credentials");
+    let credentials = { provider: "test", credentials: "credentials" };
+    Cookie.set(fetcher.authKey, JSON.stringify(credentials));
+    expect(fetcher.getAuthCredentials()).to.deep.equal(credentials);
   });
 
-  it("clears basic auth credentials", () => {
+  it("clears auth credentials", () => {
     let fetcher = new DataFetcher();
-    Cookie.set(fetcher.basicAuthKey, "credentials");
-    fetcher.clearBasicAuthCredentials();
-    expect(Cookie.get(fetcher.basicAuthKey)).to.equal(undefined);
+    let credentials = { provider: "test", credentials: "credentials" };
+    Cookie.set(fetcher.authKey, JSON.stringify(credentials));
+    fetcher.clearAuthCredentials();
+    expect(Cookie.get(fetcher.authKey)).to.equal(undefined);
   });
 
   describe("fetchOPDSData()", () => {

--- a/packages/opds-web-client/src/__tests__/actions-test.ts
+++ b/packages/opds-web-client/src/__tests__/actions-test.ts
@@ -258,29 +258,30 @@ describe("actions", () => {
     });
   });
 
-  describe("closeErrorAndHideBasicAuthForm", () => {
+  describe("closeErrorAndHideAuthForm", () => {
     it("closes error message", () => {
       let dispatch = stub();
-      actions.closeErrorAndHideBasicAuthForm()(dispatch);
+      actions.closeErrorAndHideAuthForm()(dispatch);
       expect(dispatch.callCount).to.equal(2);
       expect(dispatch.args[0][0].type).to.equal(actions.CLOSE_ERROR);
-      expect(dispatch.args[1][0].type).to.equal(actions.HIDE_BASIC_AUTH_FORM);
+      expect(dispatch.args[1][0].type).to.equal(actions.HIDE_AUTH_FORM);
     });
   });
 
-  describe("saveBasicAuthCredentials", () => {
-    it("sets fetcher credentaials", () => {
-      actions.saveBasicAuthCredentials("credentials");
-      expect((fetcher.setBasicAuthCredentials as any).callCount).to.equal(1);
-      expect((fetcher.setBasicAuthCredentials as any).args[0][0]).to.equal("credentials");
+  describe("saveAuthCredentials", () => {
+    it("sets fetcher credentials", () => {
+      let credentials = { provider: "test", credentials: "credentials" };
+      actions.saveAuthCredentials(credentials);
+      expect((fetcher.setAuthCredentials as any).callCount).to.equal(1);
+      expect((fetcher.setAuthCredentials as any).args[0][0]).to.deep.equal(credentials);
     });
   });
 
-  describe("clearBasicAuthCredentials", () => {
-    it("clears fetcher credentaials", () => {
-      fetcher.clearBasicAuthCredentials = stub();
-      actions.clearBasicAuthCredentials();
-      expect((fetcher.clearBasicAuthCredentials as any).callCount).to.equal(1);
+  describe("clearAuthCredentials", () => {
+    it("clears fetcher credentials", () => {
+      fetcher.clearAuthCredentials = stub();
+      actions.clearAuthCredentials();
+      expect((fetcher.clearAuthCredentials as any).callCount).to.equal(1);
     });
   });
 });

--- a/packages/opds-web-client/src/__tests__/authMiddleware-test.ts
+++ b/packages/opds-web-client/src/__tests__/authMiddleware-test.ts
@@ -1,0 +1,267 @@
+import { expect } from "chai";
+import { stub, spy } from "sinon";
+
+import createAuthMiddleware from "../authMiddleware";
+import * as ActionCreator from "../actions";
+import DataFetcher from "../DataFetcher";
+
+let hideAuthFormStub;
+let clearAuthCredentialsStub;
+let showAuthFormStub;
+
+class MockActionCreator extends ActionCreator.default {
+  hideAuthForm() {
+    return hideAuthFormStub();
+  }
+
+  clearAuthCredentials() {
+    return clearAuthCredentialsStub();
+  }
+
+  showAuthForm(callback, cancel, authProviders, title, error) {
+    callback();
+    return showAuthFormStub(callback, cancel, authProviders, title, error);
+  }
+}
+
+describe("authMiddleware", () => {
+  let actionCreatorStub;
+  let next;
+  let authMiddleware;
+  let plugin;
+  let pathFor;
+  let store;
+  let dataFetcher;
+
+  beforeEach(() => {
+    dataFetcher = new DataFetcher();
+    dataFetcher.clearAuthCredentials();
+    hideAuthFormStub = stub();
+    clearAuthCredentialsStub = stub();
+    showAuthFormStub = stub();
+    actionCreatorStub = stub(ActionCreator, "default", MockActionCreator);
+    next = stub().returns(new Promise((resolve, reject) => { resolve({}); }));
+
+    store = {
+      dispatch: stub().returns(new Promise((resolve, reject) => { resolve({}); })),
+      getState: stub()
+    };
+
+    plugin = {
+       type: "test",
+       lookForCredentials: stub(),
+       formComponent: null,
+       buttonComponent: null
+    };
+
+    pathFor = stub();
+
+    authMiddleware = createAuthMiddleware([plugin], pathFor);
+  });
+
+  afterEach(() => {
+    actionCreatorStub.restore();
+  });
+
+  it("handles a plain action (not a thunk)", () => {
+    let next = stub();
+    authMiddleware(store)(next)({});
+    expect(hideAuthFormStub.callCount).to.equal(1);
+    expect(next.callCount).to.equal(2);
+  });
+
+  it("hides the auth form, calls the action, and does nothing else if it succeeds", (done) => {
+    authMiddleware(store)(next)(() => {}).then(() => {
+      expect(hideAuthFormStub.callCount).to.equal(1);
+      expect(next.callCount).to.equal(2);
+      done();
+    }).catch(err => { console.log(err); throw(err); });
+  });
+
+  it("hides the auth form, calls the action, and hides the auth form again if the action returns a non-401 error", (done) => {
+    next.onCall(1).returns(new Promise((resolve, reject) => { reject({status: 500}); }));
+    authMiddleware(store)(next)(() => {}).then((arg) => {
+      expect(hideAuthFormStub.callCount).to.equal(2);
+      expect(next.callCount).to.equal(3);
+      done();
+    }).catch(err => { console.log(err); throw(err); });
+  });
+
+  it("hides the auth form, calls the action, and does nothing else if the error response wasn't json", (done) => {
+    let error = {
+      status: 401,
+      response: "not json"
+    };
+    next.onCall(1).returns(new Promise((resolve, reject) => { reject(error); }));
+    authMiddleware(store)(next)(() => {}).then(() => {
+      expect(hideAuthFormStub.callCount).to.equal(1);
+      expect(next.callCount).to.equal(2);
+      done();
+    }).catch(err => { console.log(err); throw(err); });
+  });
+
+  it("hides the auth form, calls the action, and does nothing else if the browser's default basic auth form was shown", (done) => {
+    let error = {
+      status: 401,
+      response: JSON.stringify({ title: "error" }),
+      headers: {
+        "www-authenticate": "basic library card"
+      }
+    };
+    next.onCall(1).returns(new Promise((resolve, reject) => { reject(error); }));
+    authMiddleware(store)(next)(() => {}).then(() => {
+      expect(hideAuthFormStub.callCount).to.equal(1);
+      expect(next.callCount).to.equal(2);
+      done();
+    }).catch(err => { console.log(err); throw(err); });
+  });
+
+  it("clears existing credentials", (done) => {
+    dataFetcher.setAuthCredentials({ provider: "test", credentials: "credentials" });
+    store.getState.returns({ auth: {}, collection: {}, book: {} });
+    let error = {
+      status: 401,
+      response: JSON.stringify({ title: "error" })
+    };
+    next.onCall(1).returns(new Promise((resolve, reject) => { reject(error); }));
+    authMiddleware(store)(next)(() => {}).then(() => {
+      expect(clearAuthCredentialsStub.callCount).to.equal(1);
+      done();
+    }).catch(err => { console.log(err); throw(err); });
+  });
+
+  it("shows auth form with provider info from failed request if there were no existing credentials", (done) => {
+    store.getState.returns({ auth: {}, collection: {}, book: {} });
+    let providers = {
+      provider: {
+        name: "a provider",
+        methods: {
+          test: "test method"
+        }
+      }
+    };
+    let error = {
+      status: 401,
+      response: JSON.stringify({ name: "Library", providers: providers })
+    };
+    next.onCall(1).returns(new Promise((resolve, reject) => { reject(error); }));
+    authMiddleware(store)(next)(() => {}).then(() => {
+      expect(showAuthFormStub.callCount).to.equal(1);
+      expect(showAuthFormStub.args[0][2]).to.deep.equal([{
+        name: "a provider",
+        plugin: plugin,
+        method: "test method"
+      }]);
+      expect(showAuthFormStub.args[0][3]).to.equal("Library");
+      done();
+    }).catch(err => { console.log(err); throw(err); });
+  });
+
+  it("shows auth form with provider info from store if existing credentials failed", (done) => {
+    dataFetcher.setAuthCredentials({ provider: "test", credentials: "credentials" });
+    let providers = [{
+      name: "a provider",
+      plugin: plugin,
+      method: "test method"
+    }];
+    store.getState.returns({
+      auth: {
+        title: "Library",
+        providers: providers
+      },
+      collection: {},
+      book: {}
+    });
+    let error = {
+      status: 401,
+      response: JSON.stringify({ title: "error" })
+    };
+    next.onCall(1).returns(new Promise((resolve, reject) => { reject(error); }));
+    authMiddleware(store)(next)(() => {}).then(() => {
+      expect(showAuthFormStub.callCount).to.equal(1);
+      expect(showAuthFormStub.args[0][2]).to.deep.equal([{
+        name: "a provider",
+        plugin: plugin,
+        method: "test method"
+      }]);
+      expect(showAuthFormStub.args[0][3]).to.equal("Library");
+      done();
+    }).catch(err => { console.log(err); throw(err); });
+  });
+
+  it("does not call showAuthForm if there's no supported auth method in the provider info", (done) => {
+    store.getState.returns({ auth: {}, collection: {}, book: {} });
+    let providers = {
+      provider: {
+        name: "a provider",
+        methods: {
+          unknownMethod: "unknown method"
+        }
+      }
+    };
+    let error = {
+      status: 401,
+      response: JSON.stringify({ name: "Library", providers: providers })
+    };
+    next.onCall(1).returns(new Promise((resolve, reject) => { reject(error); }));
+    authMiddleware(store)(next)(() => {}).then(() => {
+      expect(showAuthFormStub.callCount).to.equal(0);
+      expect(hideAuthFormStub.callCount).to.equal(2);
+      done();
+    }).catch(err => { console.log(err); throw(err); });
+  });
+
+  it("makes cancel go to previous page if url has changed", (done) => {
+    store.getState.returns({ auth: {}, collection: {url: "old"}, book: {} });
+    pathFor.returns("new");
+    let providers = {
+      provider: {
+        name: "a provider",
+        methods: {
+          test: "test method"
+        }
+      }
+    };
+    let error = {
+      status: 401,
+      response: JSON.stringify({ name: "Library", providers: providers })
+    };
+    next.onCall(1).returns(new Promise((resolve, reject) => { reject(error); }));
+    authMiddleware(store)(next)(() => {}).then(() => {
+      expect(showAuthFormStub.callCount).to.equal(1);
+      let cancel = showAuthFormStub.args[0][1];
+      let historySpy = spy(history, "back");
+      cancel();
+      historySpy.restore();
+      expect(historySpy.callCount).to.equal(1);
+      done();
+    }).catch(err => { console.log(err); throw(err); });
+  });
+
+  it("makes cancel hide the form if url hasn't changed", (done) => {
+    store.getState.returns({ auth: {}, collection: {}, book: {} });
+    // blank is the value of window.location.pathname when running tests
+    pathFor.returns("blank");
+    let providers = {
+      provider: {
+        name: "a provider",
+        methods: {
+          test: "test method"
+        }
+      }
+    };
+    let error = {
+      status: 401,
+      response: JSON.stringify({ name: "Library", providers: providers })
+    };
+    next.onCall(1).returns(new Promise((resolve, reject) => { reject(error); }));
+    authMiddleware(store)(next)(() => {}).then(() => {
+      expect(showAuthFormStub.callCount).to.equal(1);
+      expect(hideAuthFormStub.callCount).to.equal(1);
+      let cancel = showAuthFormStub.args[0][1];
+      cancel();
+      expect(hideAuthFormStub.callCount).to.equal(2);
+      done();
+    }).catch(err => { console.log(err); throw(err); });
+  });
+});

--- a/packages/opds-web-client/src/actions.ts
+++ b/packages/opds-web-client/src/actions.ts
@@ -1,8 +1,7 @@
 import DataFetcher from "./DataFetcher";
-import { AuthProvider } from "./interfaces";
 import {
   CollectionData, BookData, SearchData, FetchErrorData,
-  AuthCallback, AuthCredentials
+  AuthCallback, AuthCredentials, AuthProvider, AuthMethod
 } from "./interfaces";
 
 export interface LoadCollectionAction {
@@ -314,7 +313,7 @@ export default class ActionCreator {
   showAuthForm(
     callback: AuthCallback,
     cancel: () => void,
-    providers: AuthProvider[],
+    providers: AuthProvider<AuthMethod>[],
     title: string,
     error?: string
   ) {

--- a/packages/opds-web-client/src/actions.ts
+++ b/packages/opds-web-client/src/actions.ts
@@ -1,7 +1,8 @@
 import DataFetcher from "./DataFetcher";
+import { AuthProvider } from "./interfaces";
 import {
   CollectionData, BookData, SearchData, FetchErrorData,
-  BasicAuthCallback, BasicAuthLabels
+  AuthCallback, AuthCredentials
 } from "./interfaces";
 
 export interface LoadCollectionAction {
@@ -47,10 +48,10 @@ export default class ActionCreator {
   FETCH_LOANS_FAILURE = "FETCH_LOANS_FAILURE";
   LOAD_LOANS = "LOAD_LOANS";
 
-  SHOW_BASIC_AUTH_FORM = "SHOW_BASIC_AUTH_FORM";
-  HIDE_BASIC_AUTH_FORM = "HIDE_BASIC_AUTH_FORM";
-  SAVE_BASIC_AUTH_CREDENTIALS = "SAVE_BASIC_AUTH_CREDENTIALS";
-  CLEAR_BASIC_AUTH_CREDENTIALS = "CLEAR_BASIC_AUTH_CREDENTIALS";
+  SHOW_AUTH_FORM = "SHOW_AUTH_FORM";
+  HIDE_AUTH_FORM = "HIDE_AUTH_FORM";
+  SAVE_AUTH_CREDENTIALS = "SAVE_AUTH_CREDENTIALS";
+  CLEAR_AUTH_CREDENTIALS = "CLEAR_AUTH_CREDENTIALS";
 
   constructor(fetcher: DataFetcher) {
     this.fetcher = fetcher;
@@ -310,33 +311,34 @@ export default class ActionCreator {
     return { type: this.LOAD_LOANS, books };
   }
 
-  showBasicAuthForm(
-    callback: BasicAuthCallback,
-    labels: BasicAuthLabels,
+  showAuthForm(
+    callback: AuthCallback,
+    cancel: () => void,
+    providers: AuthProvider[],
     title: string,
     error?: string
   ) {
-    return { type: this.SHOW_BASIC_AUTH_FORM, callback, labels, title, error };
+    return { type: this.SHOW_AUTH_FORM, callback, cancel, providers, title, error };
   }
 
-  closeErrorAndHideBasicAuthForm() {
+  closeErrorAndHideAuthForm() {
     return (dispatch) => {
       dispatch(this.closeError());
-      dispatch(this.hideBasicAuthForm());
+      dispatch(this.hideAuthForm());
     };
   }
 
-  hideBasicAuthForm() {
-    return { type: this.HIDE_BASIC_AUTH_FORM };
+  hideAuthForm() {
+    return { type: this.HIDE_AUTH_FORM };
   }
 
-  saveBasicAuthCredentials(credentials: string) {
-    this.fetcher.setBasicAuthCredentials(credentials);
-    return { type: this.SAVE_BASIC_AUTH_CREDENTIALS, credentials };
+  saveAuthCredentials(credentials: AuthCredentials) {
+    this.fetcher.setAuthCredentials(credentials);
+    return { type: this.SAVE_AUTH_CREDENTIALS, credentials };
   }
 
-  clearBasicAuthCredentials() {
-    this.fetcher.clearBasicAuthCredentials();
-    return { type: this.CLEAR_BASIC_AUTH_CREDENTIALS };
+  clearAuthCredentials() {
+    this.fetcher.clearAuthCredentials();
+    return { type: this.CLEAR_AUTH_CREDENTIALS };
   }
 }

--- a/packages/opds-web-client/src/app.tsx
+++ b/packages/opds-web-client/src/app.tsx
@@ -5,6 +5,7 @@ import OPDSCatalog from "./components/OPDSCatalog";
 import { RootProps } from "./components/Root";
 import { PathFor } from "./interfaces";
 import { State } from "./state";
+import AuthPlugin from "./AuthPlugin";
 import "./stylesheets/app.scss";
 
 class OPDSWebClient {
@@ -15,6 +16,7 @@ class OPDSWebClient {
   constructor(config: {
     headerTitle?: string;
     proxyUrl?: string;
+    authPlugins?: AuthPlugin[];
     pageTitleTemplate?: (collectionTitle: string, bookTitle: string) => string;
     pathPattern?: string;
     pathFor: PathFor;

--- a/packages/opds-web-client/src/authMiddleware.ts
+++ b/packages/opds-web-client/src/authMiddleware.ts
@@ -1,7 +1,7 @@
 import DataFetcher from "./DataFetcher";
 import AuthPlugin from "./AuthPlugin";
 import ActionCreator from "./actions";
-import { AuthCallback, AuthProvider, PathFor } from "./interfaces";
+import { AuthCallback, AuthProvider, AuthMethod, PathFor } from "./interfaces";
 
 // see Redux Middleware docs:
 // http://redux.js.org/docs/advanced/Middleware.html
@@ -45,7 +45,7 @@ export default (authPlugins: AuthPlugin[], pathFor: PathFor) => {
                 }
 
                 // find providers with supported auth method
-                let authProviders: AuthProvider[] = [];
+                let authProviders: AuthProvider<AuthMethod>[] = [];
                 authPlugins.forEach(plugin => {
                   let providerKey = data.providers && Object.keys(data.providers).find(key => {
                     return Object.keys(data.providers[key].methods).indexOf(plugin.type) !== -1;

--- a/packages/opds-web-client/src/authMiddleware.ts
+++ b/packages/opds-web-client/src/authMiddleware.ts
@@ -63,9 +63,8 @@ export default (authPlugins: AuthPlugin[], pathFor: PathFor) => {
                 ) {
                   let callback: AuthCallback = () => {
                     // use dispatch() instead of next() to start from the top
-                    store.dispatch(action).then(blob => {
-                      resolve(blob);
-                    }).catch(reject);
+                    store.dispatch(action);
+                    resolve();
                   };
 
                   // if the collection and book urls in the state don't match
@@ -78,9 +77,8 @@ export default (authPlugins: AuthPlugin[], pathFor: PathFor) => {
                   let cancel;
                   if (pathFor(oldCollectionUrl, oldBookUrl) === currentUrl) {
                     cancel = () => {
-                      store.dispatch(actions.hideAuthForm()).then(() => {
-                        resolve();
-                      }).catch(reject);
+                      store.dispatch(actions.hideAuthForm());
+                      resolve();
                     };
                   } else {
                     cancel = () => {

--- a/packages/opds-web-client/src/authMiddleware.ts
+++ b/packages/opds-web-client/src/authMiddleware.ts
@@ -77,13 +77,11 @@ export default (authPlugins: AuthPlugin[], pathFor: PathFor) => {
                   let cancel;
                   if (pathFor(oldCollectionUrl, oldBookUrl) === currentUrl) {
                     cancel = () => {
-                      store.dispatch(actions.hideAuthForm());
-                      resolve();
+                      next(actions.hideAuthForm());
                     };
                   } else {
                     cancel = () => {
                       history.back();
-                      resolve();
                     };
                   }
 

--- a/packages/opds-web-client/src/authMiddleware.ts
+++ b/packages/opds-web-client/src/authMiddleware.ts
@@ -1,113 +1,137 @@
 import DataFetcher from "./DataFetcher";
+import AuthPlugin from "./AuthPlugin";
 import ActionCreator from "./actions";
-import { BasicAuthCallback } from "./interfaces";
+import { AuthCallback, AuthProvider, PathFor } from "./interfaces";
 
 // see Redux Middleware docs:
 // http://redux.js.org/docs/advanced/Middleware.html
 
-const BASIC_AUTH = "http://opds-spec.org/auth/basic";
+export default (authPlugins: AuthPlugin[], pathFor: PathFor) => {
+  return store => next => action => {
+    let fetcher = new DataFetcher();
+    let actions = new ActionCreator(fetcher);
 
-export default store => next => action => {
-  let fetcher = new DataFetcher();
-  let actions = new ActionCreator(fetcher);
+    if (typeof action === "function") {
+      return new Promise((resolve, reject) => {
+        next(actions.hideAuthForm());
+        let result = next(action);
 
-  if (typeof action === "function") {
-    return new Promise((resolve, reject) => {
-      next(actions.hideBasicAuthForm());
-      let result = next(action);
+        if (result && result.then) {
+          result.then(resolve).catch(err => {
+            if (err.status === 401) {
+              let error;
+              let data;
 
-      if (result && result.then) {
-        result.then(resolve).catch(err => {
-          if (err.status === 401) {
-            let error;
-            let data;
-
-            // response might not be JSON
-            try {
-              data = JSON.parse(err.response);
-            } catch (e) {
-              reject(err);
-              return;
-            }
-
-            if (err.headers && err.headers.has("www-authenticate")) {
-              // browser's default basic auth form was shown,
-              // so don't show ours
-              reject(err);
-            } else {
-              // clear any invalid credentials
-              let usedBasicAuth = !!fetcher.getBasicAuthCredentials();
-              if (usedBasicAuth) {
-                // 401s resulting from wrong username/password return
-                // problem detail documents, not auth documents
-                error = data.title;
-                store.dispatch(actions.clearBasicAuthCredentials());
+              // response might not be JSON
+              try {
+                data = JSON.parse(err.response);
+              } catch (e) {
+                reject(err);
+                return;
               }
 
-              // find provider with basic auth method
-              let provider = data.providers && Object.keys(data.providers).find(key => {
-                return Object.keys(data.providers[key].methods).indexOf(BASIC_AUTH) !== -1;
-              });
-
-              if (
-                usedBasicAuth ||
-                provider
-              ) {
-                let callback: BasicAuthCallback = () => {
-                  // use dispatch() instead of next() to start from the top
-                  store.dispatch(action).then(blob => {
-                    resolve(blob);
-                  }).catch(reject);
-                };
-
-                let title, labels;
-
-                // if previous basic auth failed, we have to get title and
-                // labels from store, instead of response data
-                if (usedBasicAuth) {
-                  let state = store.getState();
-                  title = state.auth.title;
-                  labels = {
-                    login: state.auth.loginLabel,
-                    password: state.auth.passwordLabel
-                  };
-                } else {
-                  title = data.name;
-                  labels = data.providers[provider].methods[BASIC_AUTH].labels;
+              if (err.headers && err.headers.has("www-authenticate")) {
+                // browser's default basic auth form was shown,
+                // so don't show ours
+                reject(err);
+              } else {
+                // clear any invalid credentials
+                let existingAuth = !!fetcher.getAuthCredentials();
+                if (existingAuth) {
+                  // 401s resulting from wrong username/password return
+                  // problem detail documents, not auth documents
+                  error = data.title;
+                  store.dispatch(actions.clearAuthCredentials());
                 }
 
-                next(actions.closeError());
-                next(actions.showBasicAuthForm(
-                  callback,
-                  labels,
-                  title,
-                  error
-                ));
-              } else {
-                // no provider found with basic auth method
-                // currently this custom response will not make it to the user,
-                // becuase the fetch error has already been dispatched by
-                // fetchCollectionFailure, fetchBookFailure, etc
-                next(actions.hideBasicAuthForm());
-                reject({
-                  status: 401,
-                  response: "Authentication is required but no compatible authentication method was found.",
-                  url: err.url
+                // find providers with supported auth method
+                let authProviders: AuthProvider[] = [];
+                authPlugins.forEach(plugin => {
+                  let providerKey = data.providers && Object.keys(data.providers).find(key => {
+                    return Object.keys(data.providers[key].methods).indexOf(plugin.type) !== -1;
+                  });
+                  if (providerKey) {
+                    let provider = data.providers[providerKey];
+                    let method = provider.methods[plugin.type];
+                    authProviders.push({ name: provider.name, plugin, method });
+                  }
                 });
-              }
-            }
-          } else {
-            next(actions.hideBasicAuthForm());
-            reject(err);
-          }
-        });
-      }
-    }).catch(err => {
-      // this is where we could potentially dispatch a custom auth error action
-      // displaying a more informative error
-    });
-  }
 
-  next(actions.hideBasicAuthForm());
-  next(action);
+                if (
+                  existingAuth ||
+                  authProviders.length
+                ) {
+                  let callback: AuthCallback = () => {
+                    // use dispatch() instead of next() to start from the top
+                    store.dispatch(action).then(blob => {
+                      resolve(blob);
+                    }).catch(reject);
+                  };
+
+                  // if the collection and book urls in the state don't match
+                  // the current url, we're on a page that requires authentication
+                  // and cancel should go back to the previous page. otherwise,
+                  // it should just close the form.
+                  let oldCollectionUrl = store.getState().collection.url;
+                  let oldBookUrl = store.getState().book.url;
+                  let currentUrl = window.location.pathname;
+                  let cancel;
+                  if (pathFor(oldCollectionUrl, oldBookUrl) === currentUrl) {
+                    cancel = () => {
+                      store.dispatch(actions.hideAuthForm());
+                    };
+                  } else {
+                    cancel = () => {
+                      history.back();
+                    };
+                  }
+
+                  let title;
+
+                  // if previous auth failed, we have to get providers
+                  // from store, instead of response data
+                  if (existingAuth) {
+                    let state = store.getState();
+                    title = state.auth.title;
+                    authProviders = state.auth.providers;
+                  } else {
+                    title = data.name;
+                  }
+
+                  next(actions.closeError());
+                  next(actions.showAuthForm(
+                    callback,
+                    cancel,
+                    authProviders,
+                    title,
+                    error
+                  ));
+                } else {
+                  // no provider found with basic auth method
+                  // currently this custom response will not make it to the user,
+                  // becuase the fetch error has already been dispatched by
+                  // fetchCollectionFailure, fetchBookFailure, etc
+                  next(actions.hideAuthForm());
+                  reject({
+                    status: 401,
+                    response: "Authentication is required but no compatible authentication method was found.",
+                    url: err.url
+                  });
+                }
+              }
+            } else {
+              next(actions.hideAuthForm());
+              reject(err);
+            }
+          });
+        }
+      }).catch(err => {
+        // this is where we could potentially dispatch a custom auth error action
+        // displaying a more informative error
+      });
+    }
+
+    next(actions.hideAuthForm());
+    next(action);
+  };
 };

--- a/packages/opds-web-client/src/authMiddleware.ts
+++ b/packages/opds-web-client/src/authMiddleware.ts
@@ -30,7 +30,7 @@ export default (authPlugins: AuthPlugin[], pathFor: PathFor) => {
                 return;
               }
 
-              if (err.headers && err.headers.has("www-authenticate")) {
+              if (err.headers && err.headers["www-authenticate"]) {
                 // browser's default basic auth form was shown,
                 // so don't show ours
                 reject(err);
@@ -78,11 +78,14 @@ export default (authPlugins: AuthPlugin[], pathFor: PathFor) => {
                   let cancel;
                   if (pathFor(oldCollectionUrl, oldBookUrl) === currentUrl) {
                     cancel = () => {
-                      store.dispatch(actions.hideAuthForm());
+                      store.dispatch(actions.hideAuthForm()).then(() => {
+                        resolve();
+                      }).catch(reject);
                     };
                   } else {
                     cancel = () => {
                       history.back();
+                      resolve();
                     };
                   }
 

--- a/packages/opds-web-client/src/components/AuthProviderSelectionForm.tsx
+++ b/packages/opds-web-client/src/components/AuthProviderSelectionForm.tsx
@@ -1,17 +1,17 @@
 import * as React from "react";
-import { AuthCallback, AuthCredentials, AuthProvider } from "../interfaces";
+import { AuthCallback, AuthCredentials, AuthProvider, AuthMethod } from "../interfaces";
 
-export interface AuthFormProps {
+export interface AuthFormProps<T extends AuthMethod> {
   hide?: () => void;
   saveCredentials?: (credentials: AuthCredentials) => void;
   callback?: AuthCallback;
   cancel?: () => void;
   error?: string;
-  provider?: AuthProvider;
+  provider?: AuthProvider<T>;
 }
 
-export interface AuthButtonProps {
-  provider?: AuthProvider;
+export interface AuthButtonProps<T extends AuthMethod> {
+  provider?: AuthProvider<T>;
 }
 
 export interface AuthProviderSelectionFormProps {
@@ -21,7 +21,7 @@ export interface AuthProviderSelectionFormProps {
   cancel: () => void;
   title?: string;
   error?: string;
-  providers?: AuthProvider[];
+  providers?: AuthProvider<AuthMethod>[];
 }
 
 export default class AuthProviderSelectionForm extends React.Component<AuthProviderSelectionFormProps, any> {

--- a/packages/opds-web-client/src/components/AuthProviderSelectionForm.tsx
+++ b/packages/opds-web-client/src/components/AuthProviderSelectionForm.tsx
@@ -5,6 +5,7 @@ export interface AuthFormProps {
   hide?: () => void;
   saveCredentials?: (credentials: AuthCredentials) => void;
   callback?: AuthCallback;
+  cancel?: () => void;
   error?: string;
   provider?: AuthProvider;
 }
@@ -35,26 +36,29 @@ export default class AuthProviderSelectionForm extends React.Component<AuthProvi
 
     return (
       <div className="auth-form">
-        <h3>{ this.props.title + " " || ""}Login</h3>
+        <h3>{ this.props.title ? this.props.title + " " : ""}Login</h3>
         { this.state.selectedProvider &&
           <AuthForm
             hide={this.props.hide}
             saveCredentials={this.props.saveCredentials}
             callback={this.props.callback}
+            cancel={this.props.cancel}
             error={this.props.error}
             provider={this.state.selectedProvider}
           />
         }
         { !this.state.selectedProvider && this.props.providers && this.props.providers.length > 0 &&
-          <ul className="subtle-list" aria-label="authentication options">
-            { this.props.providers.map(provider =>
-              <li onClick={() => this.selectProvider(provider)} key={provider.name}>
-                <provider.plugin.buttonComponent provider={provider}/>
-              </li>
-            ) }
-          </ul>
+          <div>
+            <ul className="subtle-list" aria-label="authentication options">
+              { this.props.providers.map(provider =>
+                <li onClick={() => this.selectProvider(provider)} key={provider.name}>
+                  <provider.plugin.buttonComponent provider={provider}/>
+                </li>
+              ) }
+            </ul>
+            <button className="btn btn-default" onClick={this.props.cancel}>Cancel</button>
+          </div>
         }
-        <button className="btn btn-default" onClick={this.props.cancel}>Cancel</button>
       </div>
     );
   }

--- a/packages/opds-web-client/src/components/AuthProviderSelectionForm.tsx
+++ b/packages/opds-web-client/src/components/AuthProviderSelectionForm.tsx
@@ -1,0 +1,71 @@
+import * as React from "react";
+import { AuthCallback, AuthCredentials, AuthProvider } from "../interfaces";
+
+export interface AuthFormProps {
+  hide?: () => void;
+  saveCredentials?: (credentials: AuthCredentials) => void;
+  callback?: AuthCallback;
+  error?: string;
+  provider?: AuthProvider;
+}
+
+export interface AuthButtonProps {
+  provider?: AuthProvider;
+}
+
+export interface AuthProviderSelectionFormProps {
+  hide: () => void;
+  saveCredentials: (credentials: AuthCredentials) => void;
+  callback?: AuthCallback;
+  cancel: () => void;
+  title?: string;
+  error?: string;
+  providers?: AuthProvider[];
+}
+
+export default class AuthProviderSelectionForm extends React.Component<AuthProviderSelectionFormProps, any> {
+  constructor(props) {
+    super(props);
+    this.state = { selectedProvider: null };
+    this.selectProvider = this.selectProvider.bind(this);
+  }
+
+  render() {
+    let AuthForm = this.state.selectedProvider && this.state.selectedProvider.plugin.formComponent;
+
+    return (
+      <div className="auth-form">
+        <h3>{ this.props.title + " " || ""}Login</h3>
+        { this.state.selectedProvider &&
+          <AuthForm
+            hide={this.props.hide}
+            saveCredentials={this.props.saveCredentials}
+            callback={this.props.callback}
+            error={this.props.error}
+            provider={this.state.selectedProvider}
+          />
+        }
+        { !this.state.selectedProvider && this.props.providers && this.props.providers.length > 0 &&
+          <ul className="subtle-list" aria-label="authentication options">
+            { this.props.providers.map(provider =>
+              <li onClick={() => this.selectProvider(provider)} key={provider.name}>
+                <provider.plugin.buttonComponent provider={provider}/>
+              </li>
+            ) }
+          </ul>
+        }
+        <input type="reset" className="btn" value="Cancel" onClick={this.props.cancel} />
+      </div>
+    );
+  }
+
+  componentWillMount() {
+    if (this.props.providers && this.props.providers.length === 1) {
+      this.setState({ selectedProvider: this.props.providers[0] });
+    }
+  }
+
+  selectProvider(provider) {
+    this.setState({ selectedProvider: provider });
+  }
+}

--- a/packages/opds-web-client/src/components/AuthProviderSelectionForm.tsx
+++ b/packages/opds-web-client/src/components/AuthProviderSelectionForm.tsx
@@ -54,7 +54,7 @@ export default class AuthProviderSelectionForm extends React.Component<AuthProvi
             ) }
           </ul>
         }
-        <input type="reset" className="btn" value="Cancel" onClick={this.props.cancel} />
+        <button className="btn btn-default" onClick={this.props.cancel}>Cancel</button>
       </div>
     );
   }

--- a/packages/opds-web-client/src/components/BasicAuthButton.tsx
+++ b/packages/opds-web-client/src/components/BasicAuthButton.tsx
@@ -1,8 +1,8 @@
 import * as React from "react";
-import { AuthProvider } from "../interfaces";
+import { AuthProvider, BasicAuthMethod } from "../interfaces";
 import { AuthButtonProps } from "./AuthProviderSelectionForm";
 
-export default class BasicAuthButton extends React.Component<AuthButtonProps, any> {
+export default class BasicAuthButton extends React.Component<AuthButtonProps<BasicAuthMethod>, any> {
   render() {
     let label = "Log in with " + this.props.provider.name;
 

--- a/packages/opds-web-client/src/components/BasicAuthButton.tsx
+++ b/packages/opds-web-client/src/components/BasicAuthButton.tsx
@@ -1,0 +1,13 @@
+import * as React from "react";
+import { AuthProvider } from "../interfaces";
+import { AuthButtonProps } from "./AuthProviderSelectionForm";
+
+export default class BasicAuthButton extends React.Component<AuthButtonProps, any> {
+  render() {
+    let label = "Log in with " + this.props.provider.name;
+
+    return (
+      <input type="submit" className="btn btn-default" value={label} />
+    );
+  }
+}

--- a/packages/opds-web-client/src/components/BasicAuthForm.tsx
+++ b/packages/opds-web-client/src/components/BasicAuthForm.tsx
@@ -32,6 +32,9 @@ export default class BasicAuthForm extends React.Component<AuthFormProps, any> {
           />
         <br />
         <input type="submit" className="btn btn-default" value="Submit" />
+        { this.props.cancel &&
+          <input type="reset" className="btn btn-default" onClick={this.props.cancel} value="Cancel" />
+        }
       </form>
     );
   }

--- a/packages/opds-web-client/src/components/BasicAuthForm.tsx
+++ b/packages/opds-web-client/src/components/BasicAuthForm.tsx
@@ -1,8 +1,10 @@
 import * as React from "react";
-import { AuthCallback, AuthProvider } from "../interfaces";
+import { AuthCallback, AuthProvider, BasicAuthMethod } from "../interfaces";
 import { AuthFormProps } from "./AuthProviderSelectionForm";
 
-export default class BasicAuthForm extends React.Component<AuthFormProps, any> {
+export interface BasicAuthFormProps extends AuthFormProps<BasicAuthMethod> {}
+
+export default class BasicAuthForm extends React.Component<BasicAuthFormProps, any> {
   constructor(props) {
     super(props);
     this.state = { error: this.props.error };

--- a/packages/opds-web-client/src/components/BasicAuthForm.tsx
+++ b/packages/opds-web-client/src/components/BasicAuthForm.tsx
@@ -1,17 +1,8 @@
 import * as React from "react";
-import { BasicAuthCallback } from "../interfaces";
+import { AuthCallback, AuthProvider } from "../interfaces";
+import { AuthFormProps } from "./AuthProviderSelectionForm";
 
-export interface BasicAuthFormProps {
-  hide: () => void;
-  saveCredentials: (credentials: string) => void;
-  callback?: BasicAuthCallback;
-  title?: string;
-  loginLabel?: string;
-  passwordLabel?: string;
-  error?: string;
-}
-
-export default class BasicAuthForm extends React.Component<BasicAuthFormProps, any> {
+export default class BasicAuthForm extends React.Component<AuthFormProps, any> {
   constructor(props) {
     super(props);
     this.state = { error: this.props.error };
@@ -20,31 +11,28 @@ export default class BasicAuthForm extends React.Component<BasicAuthFormProps, a
 
   render() {
     return (
-      <div className="auth-form">
-        <h3>{ this.props.title + " " || ""}Login</h3>
+      <form onSubmit={this.submit}>
         { this.state.error &&
           <div className="error">
             { this.state.error }
           </div>
         }
-        <form onSubmit={this.submit}>
-          <input
-            className="form-control"
-            ref="login"
-            type="text"
-            placeholder={this.loginLabel()}
-            />
-          <br />
-          <input
-            className="form-control"
-            ref="password"
-            type="password"
-            placeholder={this.passwordLabel()}
-            />
-          <br />
-          <input type="submit" className="btn btn-default" value="Submit" />
-        </form>
-      </div>
+        <input
+          className="form-control"
+          ref="login"
+          type="text"
+          placeholder={this.loginLabel()}
+          />
+        <br />
+        <input
+          className="form-control"
+          ref="password"
+          type="password"
+          placeholder={this.passwordLabel()}
+          />
+        <br />
+        <input type="submit" className="btn btn-default" value="Submit" />
+      </form>
     );
   }
 
@@ -53,11 +41,11 @@ export default class BasicAuthForm extends React.Component<BasicAuthFormProps, a
   }
 
   loginLabel() {
-    return this.props.loginLabel || "username";
+    return this.props.provider.method.labels.login || "username";
   }
 
   passwordLabel() {
-    return this.props.passwordLabel || "password";
+    return this.props.provider.method.labels.password || "password";
   }
 
   validate() {
@@ -84,16 +72,19 @@ export default class BasicAuthForm extends React.Component<BasicAuthFormProps, a
       let password = (this.refs["password"] as any).value;
       let credentials = this.generateCredentials(login, password);
 
-      this.props.saveCredentials(credentials);
+      this.props.saveCredentials({
+        provider: this.props.provider.name,
+        credentials: credentials
+      });
       this.props.hide();
 
       if (this.props.callback) {
-        this.props.callback(credentials);
+        this.props.callback();
       }
     }
   }
 
   generateCredentials(login, password) {
-    return btoa(login + ":" + password);
+    return "Basic " + btoa(login + ":" + password);
   }
 }

--- a/packages/opds-web-client/src/components/Root.tsx
+++ b/packages/opds-web-client/src/components/Root.tsx
@@ -19,7 +19,7 @@ import SkipNavigationLink from "./SkipNavigationLink";
 import CatalogLink from "./CatalogLink";
 import {
   CollectionData, BookData, LinkData, StateProps, NavigateContext,
-  AuthCallback, AuthCredentials
+  AuthCallback, AuthProvider, AuthMethod, AuthCredentials
 } from "../interfaces";
 
 export interface HeaderProps extends React.Props<any> {
@@ -27,7 +27,7 @@ export interface HeaderProps extends React.Props<any> {
   bookTitle: string;
   loansUrl?: string;
   isSignedIn: boolean;
-  fetchLoans?: (url: string) => Promise<any>;
+  fetchLoans?: (url: string) => Promise<CollectionData>;
   clearAuthCredentials: () => void;
 }
 
@@ -53,12 +53,12 @@ export interface RootProps extends StateProps {
   clearBook?: () => void;
   fetchSearchDescription?: (url: string) => void;
   closeError?: () => void;
-  fetchBook?: (bookUrl: string) => Promise<any>;
+  fetchBook?: (bookUrl: string) => Promise<BookData>;
   refreshCollectionAndBook?: () => Promise<any>;
   retryCollectionAndBook?: () => Promise<any>;
   pageTitleTemplate?: (collectionTitle: string, bookTitle: string) => string;
   headerTitle?: string;
-  fetchPage?: (url: string) => Promise<any>;
+  fetchPage?: (url: string) => Promise<CollectionData>;
   Header?: new() => __React.Component<HeaderProps, any>;
   Footer?: new() => __React.Component<FooterProps, any>;
   BookDetailsContainer?: new() =>  __React.Component<BookDetailsContainerProps, any>;
@@ -66,10 +66,10 @@ export interface RootProps extends StateProps {
   updateBook?: (url: string) => Promise<BookData>;
   fulfillBook?: (url: string) => Promise<Blob>;
   indirectFulfillBook?: (url: string, type: string) => Promise<string>;
-  fetchLoans?: (url: string) => Promise<any>;
+  fetchLoans?: (url: string) => Promise<CollectionData>;
   saveAuthCredentials?: (credentials: AuthCredentials) => void;
   clearAuthCredentials?: () => void;
-  showAuthForm?: (callback: AuthCallback, providers: any, title: string) => void;
+  showAuthForm?: (callback: AuthCallback, providers: AuthProvider<AuthMethod>[], title: string) => void;
   closeErrorAndHideAuthForm?: () => void;
 }
 

--- a/packages/opds-web-client/src/components/__tests__/AuthProviderSelectionForm-test.tsx
+++ b/packages/opds-web-client/src/components/__tests__/AuthProviderSelectionForm-test.tsx
@@ -1,0 +1,151 @@
+import { expect } from "chai";
+import { stub } from "sinon";
+
+import * as React from "react";
+import { shallow, mount } from "enzyme";
+
+import AuthProviderSelectionForm from "../AuthProviderSelectionForm";
+import BasicAuthPlugin from "../../BasicAuthPlugin";
+import BasicAuthForm from "../BasicAuthForm";
+import BasicAuthButton from "../BasicAuthButton";
+
+describe("AuthProviderSelectionForm", () => {
+  let provider1, provider2;
+
+  beforeEach(() => {
+    provider1 = {
+      name: "Provider 1",
+      plugin: BasicAuthPlugin,
+      method: {
+        labels: {
+          login: "login 1",
+          password: "password 1"
+        }
+      }
+    };
+
+    provider2 = {
+      name: "Provider 2",
+      plugin: BasicAuthPlugin,
+      method: {
+        labels: {
+          login: "login 2",
+          password: "password 2"
+        }
+      }
+    };
+  });
+
+  describe("with one provider", () => {
+    let wrapper;
+    let hide;
+    let saveCredentials;
+    let cancel;
+
+    beforeEach(() => {
+      hide = stub();
+      saveCredentials = stub();
+      cancel = stub();
+
+      wrapper = shallow(
+        <AuthProviderSelectionForm
+          hide={hide}
+          saveCredentials={saveCredentials}
+          cancel={cancel}
+          title="Intergalactic Spy Network"
+          error="you forgot the secret password! what kind of spy arre you?"
+          providers={[provider1]}
+          />
+      );
+    });
+
+    describe("rendering", () => {
+      it("shows title", () => {
+        let title = wrapper.find("h3");
+        expect(title.text()).to.equal("Intergalactic Spy Network Login");
+      });
+
+      it("shows auth form for the provider", () => {
+        let form = wrapper.find(BasicAuthForm);
+        expect(form.length).to.equal(1);
+        expect(form.props().provider).to.deep.equal(provider1);
+        expect(form.props().hide).to.equal(hide);
+        expect(form.props().saveCredentials).to.equal(saveCredentials);
+        expect(form.props().error).to.equal("you forgot the secret password! what kind of spy arre you?");
+      });
+
+      it("does not show provider selection button", () => {
+        let button = wrapper.find(BasicAuthButton);
+        expect(button.length).to.equal(0);
+      });
+
+      it("shows cancel button", () => {
+        let button = wrapper.find("input[type=\"reset\"]");
+        expect(button.length).to.equal(1);
+      });
+    });
+  });
+
+  describe("with two providers", () => {
+    let wrapper;
+    let hide;
+    let saveCredentials;
+    let cancel;
+
+    beforeEach(() => {
+      hide = stub();
+      saveCredentials = stub();
+      cancel = stub();
+
+      wrapper = mount(
+        <AuthProviderSelectionForm
+          hide={hide}
+          saveCredentials={saveCredentials}
+          cancel={cancel}
+          title="Intergalactic Spy Network"
+          error="you forgot the secret password! what kind of spy arre you?"
+          providers={[provider1, provider2]}
+          />
+      );
+    });
+
+    describe("rendering", () => {
+      it("shows title", () => {
+        let title = wrapper.find("h3");
+        expect(title.text()).to.equal("Intergalactic Spy Network Login");
+      });
+
+      it("shows auth buttons for both providers", () => {
+        let buttons = wrapper.find(BasicAuthButton);
+        expect(buttons.length).to.equal(2);
+        expect(buttons.at(0).props().provider).to.deep.equal(provider1);
+        expect(buttons.at(1).props().provider).to.deep.equal(provider2);
+      });
+
+      it("shows cancel button", () => {
+        let button = wrapper.find("input[type=\"reset\"]");
+        expect(button.length).to.equal(1);
+      });
+    });
+
+    describe("behavior", () => {
+      it("selects a provider", () => {
+        expect(wrapper.state().selectedProvider).to.be.null;
+        let buttons = wrapper.find(BasicAuthButton);
+        buttons.at(1).simulate("click");
+        expect(wrapper.state().selectedProvider).to.equal(provider2);
+      });
+
+      it("shows auth form for selected provider", () => {
+        wrapper.setState({ selectedProvider: provider1 });
+        wrapper.update();
+        let form = wrapper.find(BasicAuthForm);
+        expect(form.length).to.equal(1);
+        expect(form.props().provider).to.deep.equal(provider1);
+        expect(form.props().hide).to.equal(hide);
+        expect(form.props().saveCredentials).to.equal(saveCredentials);
+        expect(form.props().error).to.equal("you forgot the secret password! what kind of spy arre you?");
+      });
+    });
+  });
+});

--- a/packages/opds-web-client/src/components/__tests__/AuthProviderSelectionForm-test.tsx
+++ b/packages/opds-web-client/src/components/__tests__/AuthProviderSelectionForm-test.tsx
@@ -70,6 +70,7 @@ describe("AuthProviderSelectionForm", () => {
         expect(form.length).to.equal(1);
         expect(form.props().provider).to.deep.equal(provider1);
         expect(form.props().hide).to.equal(hide);
+        expect(form.props().cancel).to.equal(cancel);
         expect(form.props().saveCredentials).to.equal(saveCredentials);
         expect(form.props().error).to.equal("you forgot the secret password! what kind of spy arre you?");
       });
@@ -79,9 +80,9 @@ describe("AuthProviderSelectionForm", () => {
         expect(button.length).to.equal(0);
       });
 
-      it("shows cancel button", () => {
+      it("does not show cancel button", () => {
         let button = wrapper.find("button");
-        expect(button.length).to.equal(1);
+        expect(button.length).to.equal(0);
       });
     });
   });
@@ -143,6 +144,7 @@ describe("AuthProviderSelectionForm", () => {
         expect(form.length).to.equal(1);
         expect(form.props().provider).to.deep.equal(provider1);
         expect(form.props().hide).to.equal(hide);
+        expect(form.props().cancel).to.equal(cancel);
         expect(form.props().saveCredentials).to.equal(saveCredentials);
         expect(form.props().error).to.equal("you forgot the secret password! what kind of spy arre you?");
       });

--- a/packages/opds-web-client/src/components/__tests__/AuthProviderSelectionForm-test.tsx
+++ b/packages/opds-web-client/src/components/__tests__/AuthProviderSelectionForm-test.tsx
@@ -80,7 +80,7 @@ describe("AuthProviderSelectionForm", () => {
       });
 
       it("shows cancel button", () => {
-        let button = wrapper.find("input[type=\"reset\"]");
+        let button = wrapper.find("button");
         expect(button.length).to.equal(1);
       });
     });
@@ -123,7 +123,7 @@ describe("AuthProviderSelectionForm", () => {
       });
 
       it("shows cancel button", () => {
-        let button = wrapper.find("input[type=\"reset\"]");
+        let button = wrapper.find("button");
         expect(button.length).to.equal(1);
       });
     });

--- a/packages/opds-web-client/src/components/__tests__/BasicAuthButton-test.tsx
+++ b/packages/opds-web-client/src/components/__tests__/BasicAuthButton-test.tsx
@@ -1,0 +1,38 @@
+import { expect } from "chai";
+import { stub } from "sinon";
+
+import * as React from "react";
+import { shallow, mount } from "enzyme";
+
+import BasicAuthButton from "../BasicAuthButton";
+import BasicAuthPlugin from "../../BasicAuthPlugin";
+
+describe("BasicAuthButton", () => {
+  describe("rendering", () => {
+    let wrapper, provider;
+
+    beforeEach(() => {
+      provider = {
+        name: "Test Basic Auth",
+        plugin: BasicAuthPlugin,
+        method: {
+          labels: {
+            login: "code name",
+            password: "secret password"
+          }
+        }
+      };
+
+      wrapper = shallow(
+        <BasicAuthButton
+          provider={provider}
+          />
+      );
+    });
+
+    it("shows input with provider name", () => {
+      let input = wrapper.find("input");
+      expect(input.prop("value")).to.contain(provider.name);
+    });
+  });
+});

--- a/packages/opds-web-client/src/components/__tests__/BasicAuthForm-test.tsx
+++ b/packages/opds-web-client/src/components/__tests__/BasicAuthForm-test.tsx
@@ -27,6 +27,7 @@ describe("BasicAuthForm", () => {
         <BasicAuthForm
           hide={stub()}
           saveCredentials={stub()}
+          cancel={stub()}
           error="you forgot the secret password! what kind of spy arre you?"
           provider={provider}
           />
@@ -48,6 +49,11 @@ describe("BasicAuthForm", () => {
       expect(input.prop("value")).to.equal("Submit");
     });
 
+    it("shows cancel button", () => {
+      let button = wrapper.find("input[type='reset']");
+      expect(button.prop("value")).to.equal("Cancel");
+    });
+
     it("shows error", () => {
       let error = wrapper.find(".error");
       expect(error.text()).to.equal("you forgot the secret password! what kind of spy arre you?");
@@ -60,11 +66,13 @@ describe("BasicAuthForm", () => {
     let hide;
     let saveCredentials;
     let callback;
+    let cancel;
 
     beforeEach(() => {
       hide = stub();
       saveCredentials = stub();
       callback = stub();
+      cancel = stub();
 
       provider = {
         name: "Test Basic Auth",
@@ -82,6 +90,7 @@ describe("BasicAuthForm", () => {
           hide={hide}
           saveCredentials={saveCredentials}
           callback={callback}
+          cancel={cancel}
           error="you forgot the secret password! what kind of spy arre you?"
           provider={provider}
           />
@@ -161,6 +170,12 @@ describe("BasicAuthForm", () => {
         Object.assign({}, wrapper.props(), { error: "new error" })
       );
       expect(wrapper.state("error")).to.equal("new error");
+    });
+
+    it("cancels", () => {
+      let cancelButton = wrapper.find("input[type='reset']");
+      cancelButton.simulate("click");
+      expect(cancel.callCount).to.equal(1);
     });
   });
 });

--- a/packages/opds-web-client/src/components/__tests__/BasicAuthForm-test.tsx
+++ b/packages/opds-web-client/src/components/__tests__/BasicAuthForm-test.tsx
@@ -5,27 +5,32 @@ import * as React from "react";
 import { shallow, mount } from "enzyme";
 
 import BasicAuthForm from "../BasicAuthForm";
+import BasicAuthPlugin from "../../BasicAuthPlugin";
 
 describe("BasicAuthForm", () => {
   describe("rendering", () => {
-    let wrapper;
+    let wrapper, provider;
 
     beforeEach(() => {
+      provider = {
+        name: "Test Basic Auth",
+        plugin: BasicAuthPlugin,
+        method: {
+          labels: {
+            login: "code name",
+            password: "secret password"
+          }
+        }
+      };
+
       wrapper = shallow(
         <BasicAuthForm
           hide={stub()}
           saveCredentials={stub()}
-          title="Intergalactic Spy Network"
-          loginLabel="code name"
-          passwordLabel="secret password"
           error="you forgot the secret password! what kind of spy arre you?"
+          provider={provider}
           />
       );
-    });
-
-    it("shows title", () => {
-      let title = wrapper.find("h3");
-      expect(title.text()).to.equal("Intergalactic Spy Network Login");
     });
 
     it("shows username input", () => {
@@ -51,6 +56,7 @@ describe("BasicAuthForm", () => {
 
   describe("behavior", () => {
     let wrapper;
+    let provider;
     let hide;
     let saveCredentials;
     let callback;
@@ -59,15 +65,25 @@ describe("BasicAuthForm", () => {
       hide = stub();
       saveCredentials = stub();
       callback = stub();
+
+      provider = {
+        name: "Test Basic Auth",
+        plugin: BasicAuthPlugin,
+        method: {
+          labels: {
+            login: "code name",
+            password: "secret password"
+          }
+        }
+      };
+
       wrapper = mount(
         <BasicAuthForm
           hide={hide}
           saveCredentials={saveCredentials}
           callback={callback}
-          title="Intergalactic Spy Network"
-          loginLabel="code name"
-          passwordLabel="secret password"
           error="you forgot the secret password! what kind of spy arre you?"
+          provider={provider}
           />
       );
     });
@@ -125,7 +141,10 @@ describe("BasicAuthForm", () => {
 
       it("saves credentials", () => {
         expect(saveCredentials.callCount).to.equal(1);
-        expect(saveCredentials.args[0][0]).to.equal(credentials);
+        expect(saveCredentials.args[0][0]).to.deep.equal({
+          provider: "Test Basic Auth",
+          credentials: credentials
+        });
       });
 
       it("hides", () => {
@@ -134,7 +153,6 @@ describe("BasicAuthForm", () => {
 
       it("executes callback", () => {
         expect(callback.callCount).to.equal(1);
-        expect(callback.args[0][0]).to.equal(credentials);
       });
     });
 

--- a/packages/opds-web-client/src/components/__tests__/OPDSCatalog-test.tsx
+++ b/packages/opds-web-client/src/components/__tests__/OPDSCatalog-test.tsx
@@ -54,4 +54,21 @@ describe("OPDSCatalog", () => {
       expect(root.props()[key]).to.equal(props[key]);
     });
   });
+
+  it("checks for credentials on mount", () => {
+    let plugin = {
+      type: "test",
+      lookForCredentials: stub(),
+      formComponent: null,
+      buttonComponent: null
+    };
+    let propsWithAuthPlugin = Object.assign({}, props, {
+      authPlugins: [plugin]
+    });
+
+    let wrapper = shallow(
+      <OPDSCatalog {...propsWithAuthPlugin} />
+    );
+    expect(plugin.lookForCredentials.callCount).to.equal(1);
+  });
 });

--- a/packages/opds-web-client/src/components/__tests__/Root-test.tsx
+++ b/packages/opds-web-client/src/components/__tests__/Root-test.tsx
@@ -15,7 +15,7 @@ import CatalogLink, { CatalogLinkProps } from "../CatalogLink";
 import Search from "../Search";
 import LoadingIndicator from "../LoadingIndicator";
 import ErrorMessage from "../ErrorMessage";
-import BasicAuthForm from "../BasicAuthForm";
+import AuthProviderSelectionForm from "../AuthProviderSelectionForm";
 import { groupedCollectionData, ungroupedCollectionData } from "./collectionData";
 import buildStore from "../../store";
 import { State } from "../../state";
@@ -136,12 +136,13 @@ describe("Root", () => {
       }));
     };
     let fetchLoans = stub();
+    let credentials = { provider: "test", credentials: "credentials" };
     let wrapper = shallow(
       <Root
         collectionUrl={collectionUrl}
         setCollectionAndBook={setCollectionAndBook}
         fetchLoans={fetchLoans}
-        basicAuthCredentials="credentials"
+        authCredentials={credentials}
         />
     );
 
@@ -159,16 +160,17 @@ describe("Root", () => {
     expect(document.title).to.equal("page title");
   });
 
-  it("sets basic auth credentials on mount", () => {
-    let saveBasicAuthCredentials = stub();
+  it("sets auth credentials on mount", () => {
+    let credentials = { provider: "test", credentials: "credentials" };
+    let saveAuthCredentials = stub();
     let wrapper = shallow(
       <Root
-        saveBasicAuthCredentials={saveBasicAuthCredentials}
-        basicAuthCredentials="credentials"
+        saveAuthCredentials={saveAuthCredentials}
+        authCredentials={credentials}
         />
     );
-    expect(saveBasicAuthCredentials.callCount).to.equal(1);
-    expect(saveBasicAuthCredentials.args[0][0]).to.equal("credentials");
+    expect(saveAuthCredentials.callCount).to.equal(1);
+    expect(saveAuthCredentials.args[0][0]).to.equal(credentials);
   });
 
   it("fetches a collection url when updated", () => {
@@ -213,42 +215,42 @@ describe("Root", () => {
     expect(error.props().retry).to.equal(retry);
   });
 
-  it("shows basic auth form", () => {
-    let basicAuth = {
+  it("shows auth provider selection form", () => {
+    let auth = {
       showForm: true,
-      credentials: "gibberish",
+      credentials: { provider: "test", credentials: "gibberish"},
       title: "Super Classified Archive",
-      loginLabel: "Clearance ID",
-      passwordLabel: "Access Key",
+      providers: [],
       error: "Invalid Clearance ID and/or Access Key",
-      callback: stub()
+      callback: stub(),
+      cancel: stub()
     };
-    let saveBasicAuthCredentials = stub();
-    let closeErrorAndHideBasicAuthForm = stub();
+    let saveAuthCredentials = stub();
+    let closeErrorAndHideAuthForm = stub();
     let wrapper = shallow(
       <Root
-        basicAuth={basicAuth}
-        saveBasicAuthCredentials={saveBasicAuthCredentials}
-        closeErrorAndHideBasicAuthForm={closeErrorAndHideBasicAuthForm}
+        auth={auth}
+        saveAuthCredentials={saveAuthCredentials}
+        closeErrorAndHideAuthForm={closeErrorAndHideAuthForm}
         />
     );
-    let form = wrapper.find(BasicAuthForm);
+    let form = wrapper.find(AuthProviderSelectionForm);
     let {
-      saveCredentials, hide, callback, title, loginLabel, passwordLabel, error
+      saveCredentials, hide, callback, cancel, title, error, providers
     } = form.props();
-    expect(saveCredentials).to.equal(saveBasicAuthCredentials);
-    expect(hide).to.equal(closeErrorAndHideBasicAuthForm);
-    expect(callback).to.equal(basicAuth.callback);
-    expect(title).to.equal(basicAuth.title);
-    expect(loginLabel).to.equal(basicAuth.loginLabel);
-    expect(passwordLabel).to.equal(basicAuth.passwordLabel);
-    expect(error).to.equal(basicAuth.error);
+    expect(saveCredentials).to.equal(saveAuthCredentials);
+    expect(hide).to.equal(closeErrorAndHideAuthForm);
+    expect(callback).to.equal(auth.callback);
+    expect(cancel).to.equal(auth.cancel);
+    expect(title).to.equal(auth.title);
+    expect(providers).to.deep.equal(auth.providers);
+    expect(error).to.equal(auth.error);
   });
 
   it("shows book detail", () => {
     let bookData = groupedCollectionData.lanes[0].books[0];
     let loans = [Object.assign({}, bookData, {
-      availability: { status: "availabile" }
+      availability: { status: "available" }
     })];
     let updateBook = stub();
     let fulfillBook = stub();
@@ -470,8 +472,8 @@ describe("Root", () => {
       }
     });
     let bookData: BookData = ungroupedCollectionData.books[0];
-    let showBasicAuthForm;
-    let clearBasicAuthCredentials;
+    let fetchLoans;
+    let clearAuthCredentials;
 
     class Header extends React.Component<HeaderProps, any> {
       render(): JSX.Element {
@@ -487,13 +489,16 @@ describe("Root", () => {
     }
 
     beforeEach(() => {
+      fetchLoans = stub();
+      clearAuthCredentials = stub();
       wrapper = shallow(
         <Root
           Header={Header}
           collectionData={collectionData}
           bookData={bookData}
           fetchSearchDescription={(url: string) => {}}
-          showBasicAuthForm={showBasicAuthForm}
+          fetchLoans={fetchLoans}
+          clearAuthCredentials={clearAuthCredentials}
           isSignedIn={true}
           loansUrl="loans"
           />
@@ -506,8 +511,8 @@ describe("Root", () => {
       expect(header.props().collectionTitle).to.equal(collectionData.title);
       expect(header.props().bookTitle).to.equal(bookData.title);
       expect(header.props().isSignedIn).to.equal(true);
-      expect(header.props().showBasicAuthForm).to.equal(showBasicAuthForm);
-      expect(header.props().clearBasicAuthCredentials).to.equal(clearBasicAuthCredentials);
+      expect(header.props().fetchLoans).to.equal(fetchLoans);
+      expect(header.props().clearAuthCredentials).to.equal(clearAuthCredentials);
       expect(header.props().loansUrl).to.equal("loans");
       expect(search.type()).to.equal(Search);
     });

--- a/packages/opds-web-client/src/components/mergeRootProps.ts
+++ b/packages/opds-web-client/src/components/mergeRootProps.ts
@@ -1,7 +1,7 @@
 import ActionsCreator from "../actions";
 import DataFetcher from "../DataFetcher";
 import { adapter } from "../OPDSDataAdapter";
-import { CollectionData, BookData, BasicAuthCallback, BasicAuthLabels } from "../interfaces";
+import { CollectionData, BookData, AuthCallback, AuthCredentials } from "../interfaces";
 import { State } from "../state";
 
 export function findBookInCollection(collection: CollectionData, book: string) {
@@ -30,8 +30,8 @@ export function mapStateToProps(state, ownProps) {
     bookUrl: ownProps.bookUrl,
     loansUrl: state.loans.url,
     loans: state.loans.books,
-    basicAuth: state.auth.basic,
-    isSignedIn: !!state.auth.basic.credentials
+    auth: state.auth,
+    isSignedIn: !!state.auth.credentials
   };
 };
 
@@ -52,10 +52,10 @@ export function mapDispatchToProps(dispatch) {
         fulfillBook: (url: string) => dispatch(actions.fulfillBook(url)),
         indirectFulfillBook: (url: string, type: string) => dispatch(actions.indirectFulfillBook(url, type)),
         fetchLoans: (url: string) => dispatch(actions.fetchLoans(url)),
-        saveBasicAuthCredentials: (credentials: string) => dispatch(actions.saveBasicAuthCredentials(credentials)),
-        clearBasicAuthCredentials: () => dispatch(actions.clearBasicAuthCredentials()),
-        showBasicAuthForm: (callback: BasicAuthCallback, labels: BasicAuthLabels, title: string) => dispatch(actions.showBasicAuthForm(callback, labels, title)),
-        closeErrorAndHideBasicAuthForm: () => dispatch(actions.closeErrorAndHideBasicAuthForm())
+        saveAuthCredentials: (credentials: AuthCredentials) => dispatch(actions.saveAuthCredentials(credentials)),
+        clearAuthCredentials: () => dispatch(actions.clearAuthCredentials()),
+        showAuthForm: (callback: AuthCallback, cancel: () => void, providers: any, title: string) => dispatch(actions.showAuthForm(callback, cancel, providers, title)),
+        closeErrorAndHideAuthForm: () => dispatch(actions.closeErrorAndHideAuthForm())
       };
     }
   };
@@ -107,6 +107,7 @@ export function mergeRootProps(stateProps, createDispatchProps, componentProps) 
     adapter: adapter
   });
   let dispatchProps = createDispatchProps.createDispatchProps(fetcher);
+  let authCredentials = fetcher.getAuthCredentials();
 
   let setCollection = (url: string) => {
     return new Promise((resolve, reject) => {
@@ -177,6 +178,7 @@ export function mergeRootProps(stateProps, createDispatchProps, componentProps) 
   };
 
   return Object.assign({}, componentProps, stateProps, dispatchProps, {
+    authCredentials: authCredentials,
     setCollection: setCollection,
     setBook: setBook,
     setCollectionAndBook: setCollectionAndBook,

--- a/packages/opds-web-client/src/interfaces.ts
+++ b/packages/opds-web-client/src/interfaces.ts
@@ -145,11 +145,13 @@ export interface AuthCallback {
   (): any;
 }
 
-export interface AuthProvider {
+export interface AuthProvider<T extends AuthMethod> {
   name: string;
   plugin: AuthPlugin;
-  method: any;
+  method: T;
 }
+
+export interface AuthMethod {}
 
 export interface AuthData {
   showForm: boolean;
@@ -158,10 +160,12 @@ export interface AuthData {
   credentials: AuthCredentials;
   title: string;
   error: string;
-  providers: AuthProvider[];
+  providers: AuthProvider<AuthMethod>[];
 }
 
-export interface BasicAuthLabels {
-  login: string;
-  password: string;
+export interface BasicAuthMethod extends AuthMethod {
+  labels: {
+    login: string;
+    password: string;
+  };
 }

--- a/packages/opds-web-client/src/interfaces.ts
+++ b/packages/opds-web-client/src/interfaces.ts
@@ -1,3 +1,5 @@
+import AuthPlugin from "./AuthPlugin";
+
 export interface BookData {
   id: string;
   title: string;
@@ -101,8 +103,8 @@ export interface StateProps {
   bookUrl?: string;
   isFetchingPage?: boolean;
   history?: LinkData[];
-  basicAuth?: BasicAuthData;
-  basicAuthCredentials?: string;
+  auth?: AuthData;
+  authCredentials?: AuthCredentials;
   isSignedIn?: boolean;
   loansUrl?: string;
   loans?: BookData[];
@@ -134,18 +136,29 @@ export interface NavigateContext {
   pathFor: PathFor;
 }
 
-export interface BasicAuthCallback {
-  (credentials: string): any;
+export interface AuthCredentials {
+  provider: string;
+  credentials: string;
 }
 
-export interface BasicAuthData {
+export interface AuthCallback {
+  (): any;
+}
+
+export interface AuthProvider {
+  name: string;
+  plugin: AuthPlugin;
+  method: any;
+}
+
+export interface AuthData {
   showForm: boolean;
-  callback: BasicAuthCallback;
-  credentials: string;
+  callback: AuthCallback;
+  cancel: () => void;
+  credentials: AuthCredentials;
   title: string;
-  loginLabel: string;
-  passwordLabel: string;
   error: string;
+  providers: AuthProvider[];
 }
 
 export interface BasicAuthLabels {

--- a/packages/opds-web-client/src/reducers/__tests__/auth-test.ts
+++ b/packages/opds-web-client/src/reducers/__tests__/auth-test.ts
@@ -5,70 +5,85 @@ import reducer from "../auth";
 import DataFetcher from "../../DataFetcher";
 import ActionsCreator from "../../actions";
 import { adapter } from "../../OPDSDataAdapter";
+import BasicAuthPlugin from "../../BasicAuthPlugin";
 
 let fetcher = new DataFetcher({ adapter });
 let actions = new ActionsCreator(fetcher);
 
 describe("auth reducer", () => {
   let initState = {
-    basic: {
-      showForm: false,
-      callback: null,
-      credentials: null,
-      title: null,
-      loginLabel: null,
-      passwordLabel: null,
-      error: null
-    }
+    showForm: false,
+    callback: null,
+    cancel: null,
+    credentials: null,
+    title: null,
+    error: null,
+    providers: []
   };
 
   it("returns the initial state", () => {
     expect(reducer(undefined, {})).to.deep.equal(initState);
   });
 
-  it("handles SHOW_BASIC_AUTH_FORM", () => {
+  it("handles SHOW_AUTH_FORM", () => {
     let callback = stub();
-    let labels = { login: "barcode", password: "pin" };
-    let action = actions.showBasicAuthForm(callback, labels, "library");
+    let cancel = stub();
+    let provider = {
+      name: "library",
+      plugin: BasicAuthPlugin,
+      method: {
+        labels: {
+          login: "barcode",
+          password: "pin"
+        }
+      }
+    };
+    let action = actions.showAuthForm(callback, cancel, [provider], "library");
     let newState = Object.assign({}, initState, {
-      basic: Object.assign({}, initState.basic, {
-        showForm: true,
-        callback: callback,
-        title: "library",
-        loginLabel: "barcode",
-        passwordLabel: "pin"
-      })
+      showForm: true,
+      callback: callback,
+      cancel: cancel,
+      title: "library",
+      providers: [provider]
     });
 
     expect(reducer(initState, action)).to.deep.equal(newState);
   });
 
-  it("handles HIDE_BASIC_AUTH_FORM", () => {
+  it("handles HIDE_AUTH_FORM", () => {
     let oldState = Object.assign({}, initState, {
-      basic: Object.assign({}, initState.basic, {
-        showForm: true,
-        error: "test error"
-      })
+      showForm: true,
+      error: "test error"
     });
-    let action = actions.hideBasicAuthForm();
+    let action = actions.hideAuthForm();
     let newState = Object.assign({}, oldState, {
-      basic: Object.assign({}, oldState.basic, {
-        showForm: false,
-        error: null
-      })
+      showForm: false,
+      error: null
     });
 
     expect(reducer(oldState, action)).to.deep.equal(newState);
   });
 
-  it("handles SAVE_BASIC_AUTH_CREDENTIALS", () => {
-    let action = actions.saveBasicAuthCredentials("credentials");
+  it("handles SAVE_AUTH_CREDENTIALS", () => {
+    let credentials = { provider: "test", credentials: "credentials" };
+    let action = actions.saveAuthCredentials(credentials);
     let newState = Object.assign({}, initState, {
-      basic: Object.assign({}, initState.basic, {
-        credentials: "credentials"
-      })
+      credentials: credentials
     });
 
     expect(reducer(initState, action)).to.deep.equal(newState);
+  });
+
+  it("handles CLEAR_AUTH_CREDENTIALS", () => {
+    let credentials = { provider: "test", credentials: "credentials" };
+    let oldState = Object.assign({}, initState, {
+      credentials: credentials
+    });
+    let action = actions.clearAuthCredentials();
+    let newState = Object.assign({}, initState, {
+      credentials: null
+    });
+
+    expect(reducer(oldState, action)).to.deep.equal(newState);
   });
 });

--- a/packages/opds-web-client/src/reducers/__tests__/loans-test.ts
+++ b/packages/opds-web-client/src/reducers/__tests__/loans-test.ts
@@ -64,6 +64,17 @@ describe("loans reducer", () => {
     expect(reducer(oldState, action)).to.deep.equal(newState);
   });
 
+  it("clears books on CLEAR_AUTH_CREDENTIALS", () => {
+    let oldState = Object.assign({}, initState, {
+      books: loansData
+    });
+    let action = actions.clearAuthCredentials();
+    let newState = Object.assign({}, oldState, {
+      books: []
+    });
+    expect(reducer(oldState, action)).to.deep.equal(newState);
+  });
+
   it("clears books on LOAD_UPDATE_BOOK_DATA", () => {
     let oldState = Object.assign({}, initState, {
         books: loansData

--- a/packages/opds-web-client/src/reducers/auth.ts
+++ b/packages/opds-web-client/src/reducers/auth.ts
@@ -1,59 +1,43 @@
-import { BasicAuthCallback, BasicAuthData } from "../interfaces";
+import { AuthCallback, AuthData } from "../interfaces";
 
-export interface AuthState {
-  basic: BasicAuthData;
-}
+export interface AuthState extends AuthData {};
 
 const initialState: AuthState = {
-  basic: {
-    showForm: false,
-    callback: null,
-    credentials: null,
-    title: null,
-    loginLabel: null,
-    passwordLabel: null,
-    error: null
-  }
+  showForm: false,
+  callback: null,
+  cancel: null,
+  credentials: null,
+  title: null,
+  error: null,
+  providers: []
 };
 
 export default (state: AuthState = initialState, action): AuthState => {
   switch (action.type) {
-    case "SHOW_BASIC_AUTH_FORM":
+    case "SHOW_AUTH_FORM":
       return Object.assign({}, state, {
-        basic: Object.assign({}, state.basic, {
-          showForm: true,
-          callback: action.callback,
-          title: action.error ? state.basic.title : action.title,
-          loginLabel: action.labels && action.labels.login ?
-                      action.labels.login :
-                      state.basic.loginLabel,
-          passwordLabel: action.labels && action.labels.password ?
-                         action.labels.password :
-                         state.basic.passwordLabel,
-          error: action.error || null
-        })
+        showForm: true,
+        callback: action.callback,
+        cancel: action.cancel,
+        title: action.error ? state.title : action.title,
+        error: action.error || null,
+        providers: action.providers
       });
 
-    case "HIDE_BASIC_AUTH_FORM":
+    case "HIDE_AUTH_FORM":
       return Object.assign({}, state, {
-        basic: Object.assign({}, state.basic, {
-          showForm: false,
-          error: null
-        })
+        showForm: false,
+        error: null
       });
 
-    case "SAVE_BASIC_AUTH_CREDENTIALS":
+    case "SAVE_AUTH_CREDENTIALS":
       return Object.assign({}, state, {
-        basic: Object.assign({}, state.basic, {
-          credentials: action.credentials
-        })
+        credentials: action.credentials
       });
 
-    case "CLEAR_BASIC_AUTH_CREDENTIALS":
+    case "CLEAR_AUTH_CREDENTIALS":
       return Object.assign({}, state, {
-        basic: Object.assign({}, state.basic, {
-          credentials: null
-        })
+        credentials: null
       });
 
     default:

--- a/packages/opds-web-client/src/reducers/loans.ts
+++ b/packages/opds-web-client/src/reducers/loans.ts
@@ -26,6 +26,13 @@ export default (state: LoansState = initialState, action): LoansState => {
         books: action.books
       });
 
+    case "CLEAR_AUTH_CREDENTIALS":
+      // Clear auth credentials should remove the authenticated
+      // user's loans as well.
+      return Object.assign({}, state, {
+        books: []
+      });
+
     case "LOAD_UPDATE_BOOK_DATA":
       // A book has been updated, so the loans feed is now outdated.
       // If we remove the loans, the components showing the book that

--- a/packages/opds-web-client/src/state.ts
+++ b/packages/opds-web-client/src/state.ts
@@ -13,7 +13,7 @@ export interface State {
 }
 
 export default function buildInitialState(collectionUrl: string, bookUrl: string): Promise<State> {
-  const store = buildStore(undefined, false);
+  const store = buildStore(undefined, []);
   const fetchCollectionAndBook = createFetchCollectionAndBook(store.dispatch);
   return new Promise((resolve, reject) => {
     fetchCollectionAndBook(collectionUrl, bookUrl).then(({ collectionData, bookData }) => {

--- a/packages/opds-web-client/src/store.ts
+++ b/packages/opds-web-client/src/store.ts
@@ -3,10 +3,12 @@ import reducers from "./reducers/index";
 import collection from "./reducers/collection";
 import { State } from "./state";
 const thunk = require("redux-thunk").default;
-import authMiddleware from "./authMiddleware";
+import createAuthMiddleware from "./authMiddleware";
+import AuthPlugin from "./AuthPlugin";
+import { PathFor } from "./interfaces";
 
-export default function buildStore(initialState?: State, withAuth: boolean = true): Store<State> {
-  const middlewares = withAuth ? [authMiddleware, thunk] : [thunk];
+export default function buildStore(initialState?: State, authPlugins?: AuthPlugin[], pathFor?: PathFor): Store<State> {
+  const middlewares = authPlugins && authPlugins.length ? [createAuthMiddleware(authPlugins, pathFor), thunk] : [thunk];
   return createStore<State>(
     reducers,
     initialState,

--- a/packages/opds-web-client/src/stylesheets/app.scss
+++ b/packages/opds-web-client/src/stylesheets/app.scss
@@ -1,4 +1,4 @@
-@import "basic_auth_form";
+@import "auth_form";
 @import "book";
 @import "book_cover";
 @import "book_details";

--- a/packages/opds-web-client/src/stylesheets/auth_form.scss
+++ b/packages/opds-web-client/src/stylesheets/auth_form.scss
@@ -5,15 +5,13 @@
   background-color: $pagecolor;
 
   h3, li {
-    text-align: left;
     max-width: 300px;
     margin: 0 auto 20px;
   }
 
   form {
     max-width: 300px;
-    margin: 0 auto;
-    text-align: left;
+    margin: 0 auto 10px auto;
   }
 
   .error {

--- a/packages/opds-web-client/src/stylesheets/auth_form.scss
+++ b/packages/opds-web-client/src/stylesheets/auth_form.scss
@@ -4,7 +4,7 @@
   @include popup(300px, 300px);
   background-color: $pagecolor;
 
-  h3 {
+  h3, li {
     text-align: left;
     max-width: 300px;
     margin: 0 auto 20px;

--- a/packages/opds-web-client/src/stylesheets/auth_form.scss
+++ b/packages/opds-web-client/src/stylesheets/auth_form.scss
@@ -18,4 +18,8 @@
     padding: 0.5em;
     color: #F00;
   }
+
+  .btn {
+    margin: 10px;
+  }
 }


### PR DESCRIPTION
This pr will enable logging in with clever in circulation-patron-web.

OPDSWebClient can receive a list of authPlugins that implement the AuthPlugin interface, and it will show buttons for the user to select between them. Each plugin can implement a button for that screen, and a custom form if the button does not link to another site. This package includes a single auth plugin for basic auth. 

I also added a cancel button to the auth forms, and modified the auth middleware to support this. The auth middleware didn't have any tests so I added that too.