### PR TITLE
custom url comparator for breadcrumbs

### DIFF
--- a/packages/opds-web-client/package.json
+++ b/packages/opds-web-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opds-web-client",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "OPDS web client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/packages/opds-web-client/src/components/Breadcrumbs.tsx
+++ b/packages/opds-web-client/src/components/Breadcrumbs.tsx
@@ -41,16 +41,20 @@ export function defaultComputeBreadcrumbs(collection: CollectionData, history: L
   return links;
 }
 
-export function hierarchyComputeBreadcrumbs(collection: CollectionData, history: LinkData[]): LinkData[] {
+export function hierarchyComputeBreadcrumbs(collection: CollectionData, history: LinkData[], comparator?: (url1: string, url2: string) => boolean): LinkData[] {
   let links = [];
 
   if (!collection) {
     return [];
   }
 
+  if (!comparator) {
+    comparator = (url1, url2) => (url1 === url2);
+  }
+
   let { catalogRootLink, parentLink } = collection;
 
-  if (catalogRootLink && catalogRootLink.url !== collection.url) {
+  if (catalogRootLink && !comparator(catalogRootLink.url, collection.url)) {
     links.push({
       text: catalogRootLink.text || "Catalog",
       url: catalogRootLink.url
@@ -58,8 +62,8 @@ export function hierarchyComputeBreadcrumbs(collection: CollectionData, history:
   }
 
   if (parentLink && parentLink.url && parentLink.text &&
-      (!catalogRootLink || parentLink.url !== catalogRootLink.url) &&
-      parentLink.url !== collection.url) {
+      (!catalogRootLink || !comparator(parentLink.url, catalogRootLink.url)) &&
+      !comparator(parentLink.url, collection.url)) {
     links.push({
       text: parentLink.text,
       url: parentLink.url

--- a/packages/opds-web-client/src/components/__tests__/Breadcrumbs-test.tsx
+++ b/packages/opds-web-client/src/components/__tests__/Breadcrumbs-test.tsx
@@ -127,4 +127,23 @@ describe("hierarchyComputeBreadcrumbs", () => {
     let data = Object.assign({}, collection, { catalogRootLink, parentLink });
     expect(hierarchyComputeBreadcrumbs(data, history)).to.deep.equal([catalogRootLink, parentLink]);
   });
+
+  it("uses a custom comparator if passed one", () => {
+    let catalogRootLink = {
+      url: "new root url",
+      text: "new root text"
+    };
+    let data = Object.assign({}, collection, { catalogRootLink });
+
+    // no comparator
+    expect(hierarchyComputeBreadcrumbs(data, history)).to.deep.equal([catalogRootLink, collectionLink]);
+
+    // comparator that says links are equal
+    let comparator = (url1, url2) => true;
+    expect(hierarchyComputeBreadcrumbs(data, history, comparator)).to.deep.equal([collectionLink]);
+
+    // comparator that says links are not equal
+    comparator = (url1, url2) => false;
+    expect(hierarchyComputeBreadcrumbs(data, history, comparator)).to.deep.equal([catalogRootLink, collectionLink]);
+  });
 });


### PR DESCRIPTION
This branch is for [a bug in circulation-patron-web](https://github.com/NYPL-Simplified/circulation-patron-web/issues/43) that causes "All Books" to show up twice in breadcrumbs. The problem is the code in circulation-patron-web that expands and contracts collection urls, which leaves off a trailing slash after "groups". The OPDS feed has the trailing slash, so the code to compute the breadcrumbs thinks they're different and includes both. In general, the circ manager has a number of routes that work with or without a trailing slash, so it seems reasonable to ignore that when comparing. This branch adds an option to pass in a function for comparing URLs, so circulation-patron-web can have one that ignores trailing slashes, and possibly handles CDN URLs if we end up needing that.