### PR TITLE
brought back null alt tags, and fixes for the login popup after a login error and duplicates when scrolling down to load next page

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,5 +17,8 @@
     "prod": "cd packages/opds-web-client && npm run prod && cd ../server && npm run start",
     "start": "cd packages/server && npm run start",
     "release": "cd packages/opds-web-client && npm publish"
+  },
+  "dependencies": {
+    "throttle-debounce": "^1.0.1"
   }
 }

--- a/packages/opds-web-client/package.json
+++ b/packages/opds-web-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opds-web-client",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "description": "OPDS web client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/packages/opds-web-client/src/__tests__/authMiddleware-test.ts
+++ b/packages/opds-web-client/src/__tests__/authMiddleware-test.ts
@@ -18,9 +18,9 @@ class MockActionCreator extends ActionCreator.default {
     return clearAuthCredentialsStub();
   }
 
-  showAuthForm(callback, cancel, authProviders, title, error) {
+  showAuthForm(callback, cancel, authProviders, title, error, attemptedProvider) {
     callback();
-    return showAuthFormStub(callback, cancel, authProviders, title, error);
+    return showAuthFormStub(callback, cancel, authProviders, title, error, attemptedProvider);
   }
 }
 
@@ -185,6 +185,8 @@ describe("authMiddleware", () => {
         method: "test method"
       }]);
       expect(showAuthFormStub.args[0][3]).to.equal("Library");
+      expect(showAuthFormStub.args[0][4]).to.equal("error");
+      expect(showAuthFormStub.args[0][5]).to.equal("test");
       done();
     }).catch(err => { console.log(err); throw(err); });
   });

--- a/packages/opds-web-client/src/actions.ts
+++ b/packages/opds-web-client/src/actions.ts
@@ -315,9 +315,10 @@ export default class ActionCreator {
     cancel: () => void,
     providers: AuthProvider<AuthMethod>[],
     title: string,
-    error?: string
+    error?: string,
+    attemptedProvider?: string
   ) {
-    return { type: this.SHOW_AUTH_FORM, callback, cancel, providers, title, error };
+    return { type: this.SHOW_AUTH_FORM, callback, cancel, providers, title, error, attemptedProvider };
   }
 
   closeErrorAndHideAuthForm() {

--- a/packages/opds-web-client/src/authMiddleware.ts
+++ b/packages/opds-web-client/src/authMiddleware.ts
@@ -35,9 +35,11 @@ export default (authPlugins: AuthPlugin[], pathFor: PathFor) => {
                 // so don't show ours
                 reject(err);
               } else {
-                // clear any invalid credentials
-                let existingAuth = !!fetcher.getAuthCredentials();
+                // clear any invalid credentials, after getting the provider that was used
+                let existingAuth = fetcher.getAuthCredentials();
+                let attemptedProvider: string | null = null;
                 if (existingAuth) {
+                  attemptedProvider = existingAuth.provider;
                   // 401s resulting from wrong username/password return
                   // problem detail documents, not auth documents
                   error = data.title;
@@ -113,7 +115,8 @@ export default (authPlugins: AuthPlugin[], pathFor: PathFor) => {
                       cancel,
                       authProviders,
                       title,
-                      error
+                      error,
+                      attemptedProvider
                     ));
                   }
                 } else {

--- a/packages/opds-web-client/src/authMiddleware.ts
+++ b/packages/opds-web-client/src/authMiddleware.ts
@@ -63,8 +63,11 @@ export default (authPlugins: AuthPlugin[], pathFor: PathFor) => {
                 ) {
                   let callback: AuthCallback = () => {
                     // use dispatch() instead of next() to start from the top
-                    store.dispatch(action);
-                    resolve();
+                    store.dispatch(action).then(() => {;
+                      resolve();
+                    }).catch((err) => {
+                      reject(err);
+                    });
                   };
 
                   // if the collection and book urls in the state don't match

--- a/packages/opds-web-client/src/components/AuthProviderSelectionForm.tsx
+++ b/packages/opds-web-client/src/components/AuthProviderSelectionForm.tsx
@@ -21,13 +21,23 @@ export interface AuthProviderSelectionFormProps {
   cancel: () => void;
   title?: string;
   error?: string;
+  attemptedProvider?: string;
   providers?: AuthProvider<AuthMethod>[];
 }
 
 export default class AuthProviderSelectionForm extends React.Component<AuthProviderSelectionFormProps, any> {
   constructor(props) {
     super(props);
-    this.state = { selectedProvider: null };
+    let selectedProvider = null;
+    if (this.props.error && this.props.attemptedProvider) {
+        for (let provider of this.props.providers) {
+            if (this.props.attemptedProvider === provider.name) {
+                selectedProvider = provider;
+                break;
+            }
+        }
+    }
+    this.state = { selectedProvider };
     this.selectProvider = this.selectProvider.bind(this);
   }
 

--- a/packages/opds-web-client/src/components/BasicAuthForm.tsx
+++ b/packages/opds-web-client/src/components/BasicAuthForm.tsx
@@ -15,7 +15,7 @@ export default class BasicAuthForm extends React.Component<BasicAuthFormProps, a
     return (
       <form onSubmit={this.submit}>
         { this.state.error &&
-          <div className="error">
+          <div className="auth-error">
             { this.state.error }
           </div>
         }

--- a/packages/opds-web-client/src/components/BookCover.tsx
+++ b/packages/opds-web-client/src/components/BookCover.tsx
@@ -31,7 +31,7 @@ export default class BookCover extends React.Component<BookCoverProps, any> {
           src={this.props.book.imageUrl}
           onError={this.handleError}
           className="book-cover"
-          alt={this.props.book.title}
+          alt=""
           />
       );
     }

--- a/packages/opds-web-client/src/components/Collection.tsx
+++ b/packages/opds-web-client/src/components/Collection.tsx
@@ -79,7 +79,7 @@ export default class Collection extends React.Component<CollectionProps, any> {
 
           { this.isEmpty() &&
             <div className="empty-collection-message">
-              No books here.
+              No books found.
             </div>
           }
 

--- a/packages/opds-web-client/src/components/Collection.tsx
+++ b/packages/opds-web-client/src/components/Collection.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import { debounce } from "throttle-debounce";
 import Book from "./Book";
 import CatalogLink from "./CatalogLink";
 import { Lanes } from "./Lanes";
@@ -19,6 +20,7 @@ export default class Collection extends React.Component<CollectionProps, any> {
   constructor(props) {
     super(props);
     this.fetch = this.fetch.bind(this);
+    this.handleScrollOrResize = debounce(50, this.handleScrollOrResize.bind(this));
   }
 
   render(): JSX.Element {
@@ -110,8 +112,8 @@ export default class Collection extends React.Component<CollectionProps, any> {
 
   componentDidMount() {
     let body = this.refs["collection-main"] as HTMLElement;
-    body.addEventListener("scroll", this.handleScrollOrResize.bind(this));
-    window.addEventListener("resize", this.handleScrollOrResize.bind(this));
+    body.addEventListener("scroll", this.handleScrollOrResize);
+    window.addEventListener("resize", this.handleScrollOrResize);
 
     // the first page might not fill the screen on initial load, so run handler once
     this.handleScrollOrResize();
@@ -119,8 +121,8 @@ export default class Collection extends React.Component<CollectionProps, any> {
 
   componentWillUnmount() {
     let body = this.refs["collection-main"] as HTMLElement;
-    body.removeEventListener("scroll", this.handleScrollOrResize.bind(this));
-    window.removeEventListener("resize", this.handleScrollOrResize.bind(this));
+    body.removeEventListener("scroll", this.handleScrollOrResize);
+    window.removeEventListener("resize", this.handleScrollOrResize);
   }
 
   canFetch() {

--- a/packages/opds-web-client/src/components/Root.tsx
+++ b/packages/opds-web-client/src/components/Root.tsx
@@ -195,6 +195,7 @@ export class Root extends React.Component<RootProps, any> {
               cancel={this.props.auth.cancel}
               title={this.props.auth.title}
               error={this.props.auth.error}
+              attemptedProvider={this.props.auth.attemptedProvider}
               providers={this.props.auth.providers}
               />
           }

--- a/packages/opds-web-client/src/components/__tests__/AuthProviderSelectionForm-test.tsx
+++ b/packages/opds-web-client/src/components/__tests__/AuthProviderSelectionForm-test.tsx
@@ -148,6 +148,21 @@ describe("AuthProviderSelectionForm", () => {
         expect(form.props().saveCredentials).to.equal(saveCredentials);
         expect(form.props().error).to.equal("you forgot the secret password! what kind of spy arre you?");
       });
+
+      it("selects previously attempted provider if there was an error", () => {
+          wrapper = mount(
+            <AuthProviderSelectionForm
+              hide={hide}
+              saveCredentials={saveCredentials}
+              cancel={cancel}
+              title="Intergalactic Spy Network"
+              error="you forgot the secret password! what kind of spy arre you?"
+              attemptedProvider="Provider 2"
+              providers={[provider1, provider2]}
+              />
+          );
+          expect(wrapper.state().selectedProvider).to.equal(provider2);
+      });
     });
   });
 });

--- a/packages/opds-web-client/src/components/__tests__/BasicAuthForm-test.tsx
+++ b/packages/opds-web-client/src/components/__tests__/BasicAuthForm-test.tsx
@@ -55,7 +55,7 @@ describe("BasicAuthForm", () => {
     });
 
     it("shows error", () => {
-      let error = wrapper.find(".error");
+      let error = wrapper.find(".auth-error");
       expect(error.text()).to.equal("you forgot the secret password! what kind of spy arre you?");
     });
   });

--- a/packages/opds-web-client/src/components/__tests__/BookCover-test.tsx
+++ b/packages/opds-web-client/src/components/__tests__/BookCover-test.tsx
@@ -44,10 +44,10 @@ describe("BookCover", () => {
       );
     });
 
-    it("shows the book cover with title as alt", () => {
+    it("shows the book cover with empty alt", () => {
       let image = wrapper.find("img");
       expect(image.props().src).to.equal(bookData.imageUrl);
-      expect(image.props().alt).to.equal(bookData.title);
+      expect(image.props().alt).to.equal("");
     });
 
     it("shows the placeholder cover on image error", () => {

--- a/packages/opds-web-client/src/components/__tests__/Collection-test.tsx
+++ b/packages/opds-web-client/src/components/__tests__/Collection-test.tsx
@@ -19,7 +19,7 @@ describe("Collection", () => {
     it("says the collection is empty", () => {
       let collectionData: CollectionData = Object.assign({}, groupedCollectionData, { lanes: [] });
       let wrapper = shallow(<Collection collection={collectionData} />);
-      expect(wrapper.text()).to.equal("No books here.");
+      expect(wrapper.text()).to.equal("No books found.");
     });
   });
 

--- a/packages/opds-web-client/src/components/__tests__/Collection-test.tsx
+++ b/packages/opds-web-client/src/components/__tests__/Collection-test.tsx
@@ -108,7 +108,11 @@ describe("Collection", () => {
   });
 
   describe("collection with next page", () => {
-    it("fetches next page on scroll to bottom", () => {
+    const pause = (ms = 0): Promise<void> => {
+        return new Promise<void>(resolve => setTimeout(resolve, ms));
+    };
+
+    it("fetches next page on scroll to bottom", async () => {
       let fetchPage = stub();
       let collectionData = {
         id: "test collection",
@@ -130,12 +134,13 @@ describe("Collection", () => {
       main.scrollHeight = 1;
       main.clientHeight = 1;
       (wrapper.instance() as Collection).handleScrollOrResize();
+      await pause(51);
 
       expect(fetchPage.callCount).to.equal(1);
       expect(fetchPage.args[0][0]).to.equal("next");
     });
 
-    it("fetches next page if first page doesn't fill window", () => {
+    it("fetches next page if first page doesn't fill window", async () => {
       let fetchPage = stub();
       let collectionData = {
         id: "test collection",
@@ -158,12 +163,13 @@ describe("Collection", () => {
       main.clientHeight = 1;
 
       (wrapper as any).mount();
+      await pause(51);
 
       expect(fetchPage.callCount).to.equal(1);
       expect(fetchPage.args[0][0]).to.equal("next");
     });
 
-    it("fetches next page if newly loaded page doesn't fill window", () => {
+    it("fetches next page if newly loaded page doesn't fill window", async () => {
       let fetchPage = stub();
       let collectionData = {
         id: "test collection",
@@ -186,11 +192,13 @@ describe("Collection", () => {
       main.clientHeight = 1000;
 
       (wrapper as any).mount();
+      await pause(51);
 
       expect(fetchPage.callCount).to.equal(1);
       expect(fetchPage.args[0][0]).to.equal("next");
 
       wrapper.setProps({ isFetching: false });
+      await pause(51);
 
       // body's scroll attributes haven't changed
 

--- a/packages/opds-web-client/src/components/__tests__/Root-test.tsx
+++ b/packages/opds-web-client/src/components/__tests__/Root-test.tsx
@@ -283,6 +283,7 @@ describe("Root", () => {
       title: "Super Classified Archive",
       providers: [],
       error: "Invalid Clearance ID and/or Access Key",
+      attemptedProvider: "Archive Login",
       callback: stub(),
       cancel: stub()
     };
@@ -297,7 +298,7 @@ describe("Root", () => {
     );
     let form = wrapper.find(AuthProviderSelectionForm);
     let {
-      saveCredentials, hide, callback, cancel, title, error, providers
+      saveCredentials, hide, callback, cancel, title, error, attemptedProvider, providers
     } = form.props();
     expect(saveCredentials).to.equal(saveAuthCredentials);
     expect(hide).to.equal(closeErrorAndHideAuthForm);
@@ -306,6 +307,7 @@ describe("Root", () => {
     expect(title).to.equal(auth.title);
     expect(providers).to.deep.equal(auth.providers);
     expect(error).to.equal(auth.error);
+    expect(attemptedProvider).to.equal(auth.attemptedProvider);
   });
 
   it("shows book detail", () => {

--- a/packages/opds-web-client/src/interfaces.ts
+++ b/packages/opds-web-client/src/interfaces.ts
@@ -160,7 +160,8 @@ export interface AuthData {
   cancel: () => void;
   credentials: AuthCredentials;
   title: string;
-  error: string;
+  error: string | null;
+  attemptedProvider: string | null;
   providers: AuthProvider<AuthMethod>[];
 }
 

--- a/packages/opds-web-client/src/reducers/__tests__/auth-test.ts
+++ b/packages/opds-web-client/src/reducers/__tests__/auth-test.ts
@@ -18,6 +18,7 @@ describe("auth reducer", () => {
     credentials: null,
     title: null,
     error: null,
+    attemptedProvider: null,
     providers: null
   };
 
@@ -48,6 +49,36 @@ describe("auth reducer", () => {
     });
 
     expect(reducer(initState, action)).to.deep.equal(newState);
+  });
+
+  it("handles SHOW_AUTH_FORM after error", () => {
+    let callback = stub();
+    let cancel = stub();
+    let provider = {
+      name: "library",
+      plugin: BasicAuthPlugin,
+      method: {
+        labels: {
+          login: "barcode",
+          password: "pin"
+        }
+      }
+    };
+    let error = "Invalid Credentials";
+    let attemptedProvider = "library";
+    let action = actions.showAuthForm(callback, cancel, [provider], "library", error, attemptedProvider);
+    let previousAttemptState = Object.assign({}, initState, { title: "library" });
+    let newState = Object.assign({}, previousAttemptState, {
+      showForm: true,
+      callback: callback,
+      cancel: cancel,
+      title: "library",
+      providers: [provider],
+      error: error,
+      attemptedProvider: attemptedProvider
+    });
+
+    expect(reducer(previousAttemptState, action)).to.deep.equal(newState);
   });
 
   it("handles HIDE_AUTH_FORM", () => {

--- a/packages/opds-web-client/src/reducers/auth.ts
+++ b/packages/opds-web-client/src/reducers/auth.ts
@@ -9,6 +9,7 @@ const initialState: AuthState = {
   credentials: null,
   title: null,
   error: null,
+  attemptedProvider: null,
   providers: null
 };
 
@@ -21,6 +22,7 @@ export default (state: AuthState = initialState, action): AuthState => {
         cancel: action.cancel,
         title: action.error ? state.title : action.title,
         error: action.error || null,
+        attemptedProvider: action.attemptedProvider || null,
         providers: action.providers
       });
 

--- a/packages/opds-web-client/src/stylesheets/auth_form.scss
+++ b/packages/opds-web-client/src/stylesheets/auth_form.scss
@@ -16,7 +16,7 @@
     margin: 0 auto 10px auto;
   }
 
-  .error {
+  .auth-error {
     padding: 0.5em;
     color: #F00;
   }


### PR DESCRIPTION
This pr has three small changes.

First, I restored the null alt tags on book cover images. Matthew originally set these to null because the title is right after the cover and we didn't want screen readers to read it twice. I couldn't find any info about the accessibility guidelines for this so I put the titles in temporarily, but according to webaim (1.1.1 on [this page](http://code.viget.com/interactive-wcag/#responsibility=&level=aa)) it's fine so I put the empty tags back.

Next, I fixed #181 - when scrolling down to load a new page, multiple scroll events were getting handled, and each one was triggering a separate fetch for the same page. I limited it to only send one request every 50 milliseconds so redux has time to handle the first action and propagate the loading state back down to the component.

Finally, I fixed some problems with the authentication popup. After putting in incorrect credentials, the popup would just go away and you couldn't tell that it failed. I also had to make it remember which provider you tried, so it can go back to that one if there are multiple providers.