### PR TITLE
Changed the dependency version to avoid npm install errors

### DIFF
--- a/packages/opds-web-client/package.json
+++ b/packages/opds-web-client/package.json
@@ -22,7 +22,7 @@
     "downloadjs": "^1.4.4",
     "isomorphic-fetch": "^2.2.1",
     "js-cookie": "^2.1.2",
-    "jsdom": "^9.4.1",
+    "jsdom": "9.9.1",
     "moment": "^2.14.1",
     "opds-feed-parser": "^0.0.13",
     "react": "^15.3.0",
@@ -51,7 +51,7 @@
     "style-loader": "^0.13.1",
     "ts-loader": "^0.8.2",
     "tslint": "^3.10.2",
-    "typescript": "^2.0.3",
+    "typescript": "2.1.4",
     "typings": "^1.3.1",
     "webpack": "^1.13.2",
     "webpack-dev-server": "^1.14.1"


### PR DESCRIPTION
Here is a pull request to fix npm install errors by using the right dependencies for typescript and jsdom. 