### PR TITLE
Actions refactoring

### DIFF
--- a/packages/opds-web-client/package.json
+++ b/packages/opds-web-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opds-web-client",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "description": "OPDS web client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/packages/opds-web-client/src/__mocks__/DataFetcher.ts
+++ b/packages/opds-web-client/src/__mocks__/DataFetcher.ts
@@ -5,6 +5,7 @@ import DataFetcher from "../DataFetcher";
 export default class MockDataFetcher extends DataFetcher {
   resolve: boolean = true;
   testData: any = "test";
+  testError: any = "test error";
 
   fetchOPDSData(url) {
     return this.fetch(url);
@@ -19,7 +20,7 @@ export default class MockDataFetcher extends DataFetcher {
       if (this.resolve) {
         resolve(this.testData);
       } else {
-        reject("test error");
+        reject(this.testError);
       }
     });
   }

--- a/packages/opds-web-client/src/__tests__/actions-test.ts
+++ b/packages/opds-web-client/src/__tests__/actions-test.ts
@@ -27,9 +27,9 @@ describe("actions", () => {
 
       actions.fetchCollection(collectionUrl)(dispatch).then(data => {
         expect(dispatch.callCount).to.equal(3);
-        expect(dispatch.args[0][0].type).to.equal(ActionCreator.FETCH_COLLECTION_REQUEST);
-        expect(dispatch.args[1][0].type).to.equal(ActionCreator.FETCH_COLLECTION_SUCCESS);
-        expect(dispatch.args[2][0].type).to.equal(ActionCreator.LOAD_COLLECTION);
+        expect(dispatch.args[0][0].type).to.equal(ActionCreator.COLLECTION_REQUEST);
+        expect(dispatch.args[1][0].type).to.equal(ActionCreator.COLLECTION_SUCCESS);
+        expect(dispatch.args[2][0].type).to.equal(ActionCreator.COLLECTION_LOAD);
         expect(data).to.equal(testData);
         done();
       }).catch(err => { console.log(err); throw(err); });
@@ -41,8 +41,8 @@ describe("actions", () => {
 
       actions.fetchCollection(collectionUrl)(dispatch).catch(err => {
         expect(dispatch.callCount).to.equal(2);
-        expect(dispatch.args[0][0].type).to.equal(ActionCreator.FETCH_COLLECTION_REQUEST);
-        expect(dispatch.args[1][0].type).to.equal(ActionCreator.FETCH_COLLECTION_FAILURE);
+        expect(dispatch.args[0][0].type).to.equal(ActionCreator.COLLECTION_REQUEST);
+        expect(dispatch.args[1][0].type).to.equal(ActionCreator.COLLECTION_FAILURE);
         expect(err).to.equal("test error");
         done();
       }).catch(err => { console.log(err); throw(err); });
@@ -57,9 +57,9 @@ describe("actions", () => {
 
       actions.fetchPage("http://example.com/feed")(dispatch).then(data => {
         expect(dispatch.callCount).to.equal(3);
-        expect(dispatch.args[0][0].type).to.equal(ActionCreator.FETCH_PAGE_REQUEST);
-        expect(dispatch.args[1][0].type).to.equal(ActionCreator.FETCH_PAGE_SUCCESS);
-        expect(dispatch.args[2][0].type).to.equal(ActionCreator.LOAD_PAGE);
+        expect(dispatch.args[0][0].type).to.equal(ActionCreator.PAGE_REQUEST);
+        expect(dispatch.args[1][0].type).to.equal(ActionCreator.PAGE_SUCCESS);
+        expect(dispatch.args[2][0].type).to.equal(ActionCreator.PAGE_LOAD);
         expect(data).to.equal(testData);
         done();
       }).catch(err => { console.log(err); throw(err); });
@@ -71,8 +71,8 @@ describe("actions", () => {
 
       actions.fetchPage("http://example.com/feed")(dispatch).catch(err => {
         expect(dispatch.callCount).to.equal(2);
-        expect(dispatch.args[0][0].type).to.equal(ActionCreator.FETCH_PAGE_REQUEST);
-        expect(dispatch.args[1][0].type).to.equal(ActionCreator.FETCH_PAGE_FAILURE);
+        expect(dispatch.args[0][0].type).to.equal(ActionCreator.PAGE_REQUEST);
+        expect(dispatch.args[1][0].type).to.equal(ActionCreator.PAGE_FAILURE);
         expect(err).to.equal("test error");
         done();
       }).catch(err => { console.log(err); throw(err); });
@@ -86,7 +86,7 @@ describe("actions", () => {
 
       actions.fetchSearchDescription("http://example.com/search")(dispatch).then(data => {
         expect(dispatch.callCount).to.equal(1);
-        expect(dispatch.args[0][0].type).to.equal(ActionCreator.LOAD_SEARCH_DESCRIPTION);
+        expect(dispatch.args[0][0].type).to.equal(ActionCreator.SEARCH_DESCRIPTION_LOAD);
         expect(data).to.equal(testData);
         done();
       }).catch(err => { console.log(err); throw(err); });
@@ -102,9 +102,9 @@ describe("actions", () => {
 
       actions.fetchBook(bookUrl)(dispatch).then(data => {
         expect(dispatch.callCount).to.equal(3);
-        expect(dispatch.args[0][0].type).to.equal(ActionCreator.FETCH_BOOK_REQUEST);
-        expect(dispatch.args[1][0].type).to.equal(ActionCreator.FETCH_BOOK_SUCCESS);
-        expect(dispatch.args[2][0].type).to.equal(ActionCreator.LOAD_BOOK);
+        expect(dispatch.args[0][0].type).to.equal(ActionCreator.BOOK_REQUEST);
+        expect(dispatch.args[1][0].type).to.equal(ActionCreator.BOOK_SUCCESS);
+        expect(dispatch.args[2][0].type).to.equal(ActionCreator.BOOK_LOAD);
         expect(data).to.equal(testData);
         done();
       }).catch(err => { console.log(err); throw(err); });
@@ -116,8 +116,8 @@ describe("actions", () => {
 
       actions.fetchBook(bookUrl)(dispatch).catch(err => {
         expect(dispatch.callCount).to.equal(2);
-        expect(dispatch.args[0][0].type).to.equal(ActionCreator.FETCH_BOOK_REQUEST);
-        expect(dispatch.args[1][0].type).to.equal(ActionCreator.FETCH_BOOK_FAILURE);
+        expect(dispatch.args[0][0].type).to.equal(ActionCreator.BOOK_REQUEST);
+        expect(dispatch.args[1][0].type).to.equal(ActionCreator.BOOK_FAILURE);
         expect(err).to.equal("test error");
         done();
       }).catch(err => { console.log(err); throw(err); });
@@ -138,7 +138,7 @@ describe("actions", () => {
         expect(dispatch.callCount).to.equal(3);
         expect(dispatch.args[0][0].type).to.equal(ActionCreator.UPDATE_BOOK_REQUEST);
         expect(dispatch.args[1][0].type).to.equal(ActionCreator.UPDATE_BOOK_SUCCESS);
-        expect(dispatch.args[2][0].type).to.equal(ActionCreator.LOAD_UPDATE_BOOK_DATA);
+        expect(dispatch.args[2][0].type).to.equal(ActionCreator.UPDATE_BOOK_LOAD);
         expect(data).to.equal(fetcher.testData);
         done();
       }).catch(err => { console.log(err); throw(err); });
@@ -236,9 +236,9 @@ describe("actions", () => {
 
       actions.fetchLoans(loansUrl)(dispatch).then(data => {
         expect(dispatch.callCount).to.equal(3);
-        expect(dispatch.args[0][0].type).to.equal(ActionCreator.FETCH_LOANS_REQUEST);
-        expect(dispatch.args[1][0].type).to.equal(ActionCreator.FETCH_LOANS_SUCCESS);
-        expect(dispatch.args[2][0].type).to.equal(ActionCreator.LOAD_LOANS);
+        expect(dispatch.args[0][0].type).to.equal(ActionCreator.LOANS_REQUEST);
+        expect(dispatch.args[1][0].type).to.equal(ActionCreator.LOANS_SUCCESS);
+        expect(dispatch.args[2][0].type).to.equal(ActionCreator.LOANS_LOAD);
         expect(data).to.equal(testData);
         done();
       }).catch(err => { console.log(err); throw(err); });
@@ -250,8 +250,8 @@ describe("actions", () => {
 
       actions.fetchLoans(loansUrl)(dispatch).catch(err => {
         expect(dispatch.callCount).to.equal(2);
-        expect(dispatch.args[0][0].type).to.equal(ActionCreator.FETCH_LOANS_REQUEST);
-        expect(dispatch.args[1][0].type).to.equal(ActionCreator.FETCH_LOANS_FAILURE);
+        expect(dispatch.args[0][0].type).to.equal(ActionCreator.LOANS_REQUEST);
+        expect(dispatch.args[1][0].type).to.equal(ActionCreator.LOANS_FAILURE);
         expect(err).to.equal("test error");
         done();
       }).catch(err => { console.log(err); throw(err); });

--- a/packages/opds-web-client/src/__tests__/actions-test.ts
+++ b/packages/opds-web-client/src/__tests__/actions-test.ts
@@ -14,8 +14,8 @@ import DataFetcher from "../__mocks__/DataFetcher";
 let fetcher = new DataFetcher();
 fetcher.testData = testData;
 
-import ActionsCreator from "../actions";
-let actions = new ActionsCreator(fetcher);
+import ActionCreator from "../actions";
+let actions = new ActionCreator(fetcher);
 
 describe("actions", () => {
   describe("fetchCollection", () => {
@@ -27,9 +27,9 @@ describe("actions", () => {
 
       actions.fetchCollection(collectionUrl)(dispatch).then(data => {
         expect(dispatch.callCount).to.equal(3);
-        expect(dispatch.args[0][0].type).to.equal(actions.FETCH_COLLECTION_REQUEST);
-        expect(dispatch.args[1][0].type).to.equal(actions.FETCH_COLLECTION_SUCCESS);
-        expect(dispatch.args[2][0].type).to.equal(actions.LOAD_COLLECTION);
+        expect(dispatch.args[0][0].type).to.equal(ActionCreator.FETCH_COLLECTION_REQUEST);
+        expect(dispatch.args[1][0].type).to.equal(ActionCreator.FETCH_COLLECTION_SUCCESS);
+        expect(dispatch.args[2][0].type).to.equal(ActionCreator.LOAD_COLLECTION);
         expect(data).to.equal(testData);
         done();
       }).catch(err => { console.log(err); throw(err); });
@@ -41,8 +41,8 @@ describe("actions", () => {
 
       actions.fetchCollection(collectionUrl)(dispatch).catch(err => {
         expect(dispatch.callCount).to.equal(2);
-        expect(dispatch.args[0][0].type).to.equal(actions.FETCH_COLLECTION_REQUEST);
-        expect(dispatch.args[1][0].type).to.equal(actions.FETCH_COLLECTION_FAILURE);
+        expect(dispatch.args[0][0].type).to.equal(ActionCreator.FETCH_COLLECTION_REQUEST);
+        expect(dispatch.args[1][0].type).to.equal(ActionCreator.FETCH_COLLECTION_FAILURE);
         expect(err).to.equal("test error");
         done();
       }).catch(err => { console.log(err); throw(err); });
@@ -57,9 +57,9 @@ describe("actions", () => {
 
       actions.fetchPage("http://example.com/feed")(dispatch).then(data => {
         expect(dispatch.callCount).to.equal(3);
-        expect(dispatch.args[0][0].type).to.equal(actions.FETCH_PAGE_REQUEST);
-        expect(dispatch.args[1][0].type).to.equal(actions.FETCH_PAGE_SUCCESS);
-        expect(dispatch.args[2][0].type).to.equal(actions.LOAD_PAGE);
+        expect(dispatch.args[0][0].type).to.equal(ActionCreator.FETCH_PAGE_REQUEST);
+        expect(dispatch.args[1][0].type).to.equal(ActionCreator.FETCH_PAGE_SUCCESS);
+        expect(dispatch.args[2][0].type).to.equal(ActionCreator.LOAD_PAGE);
         expect(data).to.equal(testData);
         done();
       }).catch(err => { console.log(err); throw(err); });
@@ -71,8 +71,8 @@ describe("actions", () => {
 
       actions.fetchPage("http://example.com/feed")(dispatch).catch(err => {
         expect(dispatch.callCount).to.equal(2);
-        expect(dispatch.args[0][0].type).to.equal(actions.FETCH_PAGE_REQUEST);
-        expect(dispatch.args[1][0].type).to.equal(actions.FETCH_PAGE_FAILURE);
+        expect(dispatch.args[0][0].type).to.equal(ActionCreator.FETCH_PAGE_REQUEST);
+        expect(dispatch.args[1][0].type).to.equal(ActionCreator.FETCH_PAGE_FAILURE);
         expect(err).to.equal("test error");
         done();
       }).catch(err => { console.log(err); throw(err); });
@@ -86,7 +86,7 @@ describe("actions", () => {
 
       actions.fetchSearchDescription("http://example.com/search")(dispatch).then(data => {
         expect(dispatch.callCount).to.equal(1);
-        expect(dispatch.args[0][0].type).to.equal(actions.LOAD_SEARCH_DESCRIPTION);
+        expect(dispatch.args[0][0].type).to.equal(ActionCreator.LOAD_SEARCH_DESCRIPTION);
         expect(data).to.equal(testData);
         done();
       }).catch(err => { console.log(err); throw(err); });
@@ -102,9 +102,9 @@ describe("actions", () => {
 
       actions.fetchBook(bookUrl)(dispatch).then(data => {
         expect(dispatch.callCount).to.equal(3);
-        expect(dispatch.args[0][0].type).to.equal(actions.FETCH_BOOK_REQUEST);
-        expect(dispatch.args[1][0].type).to.equal(actions.FETCH_BOOK_SUCCESS);
-        expect(dispatch.args[2][0].type).to.equal(actions.LOAD_BOOK);
+        expect(dispatch.args[0][0].type).to.equal(ActionCreator.FETCH_BOOK_REQUEST);
+        expect(dispatch.args[1][0].type).to.equal(ActionCreator.FETCH_BOOK_SUCCESS);
+        expect(dispatch.args[2][0].type).to.equal(ActionCreator.LOAD_BOOK);
         expect(data).to.equal(testData);
         done();
       }).catch(err => { console.log(err); throw(err); });
@@ -116,8 +116,8 @@ describe("actions", () => {
 
       actions.fetchBook(bookUrl)(dispatch).catch(err => {
         expect(dispatch.callCount).to.equal(2);
-        expect(dispatch.args[0][0].type).to.equal(actions.FETCH_BOOK_REQUEST);
-        expect(dispatch.args[1][0].type).to.equal(actions.FETCH_BOOK_FAILURE);
+        expect(dispatch.args[0][0].type).to.equal(ActionCreator.FETCH_BOOK_REQUEST);
+        expect(dispatch.args[1][0].type).to.equal(ActionCreator.FETCH_BOOK_FAILURE);
         expect(err).to.equal("test error");
         done();
       }).catch(err => { console.log(err); throw(err); });
@@ -136,9 +136,9 @@ describe("actions", () => {
 
       actions.updateBook(borrowUrl)(dispatch).then(data => {
         expect(dispatch.callCount).to.equal(3);
-        expect(dispatch.args[0][0].type).to.equal(actions.UPDATE_BOOK_REQUEST);
-        expect(dispatch.args[1][0].type).to.equal(actions.UPDATE_BOOK_SUCCESS);
-        expect(dispatch.args[2][0].type).to.equal(actions.LOAD_UPDATE_BOOK_DATA);
+        expect(dispatch.args[0][0].type).to.equal(ActionCreator.UPDATE_BOOK_REQUEST);
+        expect(dispatch.args[1][0].type).to.equal(ActionCreator.UPDATE_BOOK_SUCCESS);
+        expect(dispatch.args[2][0].type).to.equal(ActionCreator.LOAD_UPDATE_BOOK_DATA);
         expect(data).to.equal(fetcher.testData);
         done();
       }).catch(err => { console.log(err); throw(err); });
@@ -150,8 +150,8 @@ describe("actions", () => {
 
       actions.updateBook(borrowUrl)(dispatch).catch(err => {
         expect(dispatch.callCount).to.equal(2);
-        expect(dispatch.args[0][0].type).to.equal(actions.UPDATE_BOOK_REQUEST);
-        expect(dispatch.args[1][0].type).to.equal(actions.UPDATE_BOOK_FAILURE);
+        expect(dispatch.args[0][0].type).to.equal(ActionCreator.UPDATE_BOOK_REQUEST);
+        expect(dispatch.args[1][0].type).to.equal(ActionCreator.UPDATE_BOOK_FAILURE);
         expect(err).to.equal("test error");
         done();
       }).catch(err => { console.log(err); throw(err); });
@@ -168,8 +168,8 @@ describe("actions", () => {
 
       actions.fulfillBook(fulfillmentUrl)(dispatch).then(data => {
         expect(dispatch.callCount).to.equal(2);
-        expect(dispatch.args[0][0].type).to.equal(actions.FULFILL_BOOK_REQUEST);
-        expect(dispatch.args[1][0].type).to.equal(actions.FULFILL_BOOK_SUCCESS);
+        expect(dispatch.args[0][0].type).to.equal(ActionCreator.FULFILL_BOOK_REQUEST);
+        expect(dispatch.args[1][0].type).to.equal(ActionCreator.FULFILL_BOOK_SUCCESS);
         expect(data).to.equal("blob");
         done();
       }).catch(err => { console.log(err); throw(err); });
@@ -181,8 +181,8 @@ describe("actions", () => {
 
       actions.fulfillBook(fulfillmentUrl)(dispatch).catch(err => {
         expect(dispatch.callCount).to.equal(2);
-        expect(dispatch.args[0][0].type).to.equal(actions.FULFILL_BOOK_REQUEST);
-        expect(dispatch.args[1][0].type).to.equal(actions.FULFILL_BOOK_FAILURE);
+        expect(dispatch.args[0][0].type).to.equal(ActionCreator.FULFILL_BOOK_REQUEST);
+        expect(dispatch.args[1][0].type).to.equal(ActionCreator.FULFILL_BOOK_FAILURE);
         expect(err).to.equal("test error");
         done();
       }).catch(err => { console.log(err); throw(err); });
@@ -205,8 +205,8 @@ describe("actions", () => {
 
       actions.indirectFulfillBook(fulfillmentUrl, fulfillmentType)(dispatch).then(url => {
         expect(dispatch.callCount).to.equal(2);
-        expect(dispatch.args[0][0].type).to.equal(actions.FULFILL_BOOK_REQUEST);
-        expect(dispatch.args[1][0].type).to.equal(actions.FULFILL_BOOK_SUCCESS);
+        expect(dispatch.args[0][0].type).to.equal(ActionCreator.FULFILL_BOOK_REQUEST);
+        expect(dispatch.args[1][0].type).to.equal(ActionCreator.FULFILL_BOOK_SUCCESS);
         expect(url).to.equal(indirectUrl);
         done();
       }).catch(err => { console.log(err); throw(err); });
@@ -218,8 +218,8 @@ describe("actions", () => {
 
       actions.indirectFulfillBook(fulfillmentUrl, fulfillmentType)(dispatch).catch(err => {
         expect(dispatch.callCount).to.equal(2);
-        expect(dispatch.args[0][0].type).to.equal(actions.FULFILL_BOOK_REQUEST);
-        expect(dispatch.args[1][0].type).to.equal(actions.FULFILL_BOOK_FAILURE);
+        expect(dispatch.args[0][0].type).to.equal(ActionCreator.FULFILL_BOOK_REQUEST);
+        expect(dispatch.args[1][0].type).to.equal(ActionCreator.FULFILL_BOOK_FAILURE);
         expect(err).to.equal("test error");
         done();
       }).catch(err => { console.log(err); throw(err); });
@@ -236,9 +236,9 @@ describe("actions", () => {
 
       actions.fetchLoans(loansUrl)(dispatch).then(data => {
         expect(dispatch.callCount).to.equal(3);
-        expect(dispatch.args[0][0].type).to.equal(actions.FETCH_LOANS_REQUEST);
-        expect(dispatch.args[1][0].type).to.equal(actions.FETCH_LOANS_SUCCESS);
-        expect(dispatch.args[2][0].type).to.equal(actions.LOAD_LOANS);
+        expect(dispatch.args[0][0].type).to.equal(ActionCreator.FETCH_LOANS_REQUEST);
+        expect(dispatch.args[1][0].type).to.equal(ActionCreator.FETCH_LOANS_SUCCESS);
+        expect(dispatch.args[2][0].type).to.equal(ActionCreator.LOAD_LOANS);
         expect(data).to.equal(testData);
         done();
       }).catch(err => { console.log(err); throw(err); });
@@ -250,8 +250,8 @@ describe("actions", () => {
 
       actions.fetchLoans(loansUrl)(dispatch).catch(err => {
         expect(dispatch.callCount).to.equal(2);
-        expect(dispatch.args[0][0].type).to.equal(actions.FETCH_LOANS_REQUEST);
-        expect(dispatch.args[1][0].type).to.equal(actions.FETCH_LOANS_FAILURE);
+        expect(dispatch.args[0][0].type).to.equal(ActionCreator.FETCH_LOANS_REQUEST);
+        expect(dispatch.args[1][0].type).to.equal(ActionCreator.FETCH_LOANS_FAILURE);
         expect(err).to.equal("test error");
         done();
       }).catch(err => { console.log(err); throw(err); });
@@ -263,8 +263,8 @@ describe("actions", () => {
       let dispatch = stub();
       actions.closeErrorAndHideAuthForm()(dispatch);
       expect(dispatch.callCount).to.equal(2);
-      expect(dispatch.args[0][0].type).to.equal(actions.CLOSE_ERROR);
-      expect(dispatch.args[1][0].type).to.equal(actions.HIDE_AUTH_FORM);
+      expect(dispatch.args[0][0].type).to.equal(ActionCreator.CLOSE_ERROR);
+      expect(dispatch.args[1][0].type).to.equal(ActionCreator.HIDE_AUTH_FORM);
     });
   });
 

--- a/packages/opds-web-client/src/__tests__/actions-test.ts
+++ b/packages/opds-web-client/src/__tests__/actions-test.ts
@@ -1,6 +1,8 @@
 import { expect } from "chai";
 import { stub } from "sinon";
 
+import { CollectionData } from "../interfaces";
+
 let testData = {
   lanes: [],
   books: [{
@@ -12,115 +14,268 @@ let testData = {
 
 import DataFetcher from "../__mocks__/DataFetcher";
 let fetcher = new DataFetcher();
-fetcher.testData = testData;
 
 import ActionCreator from "../actions";
 let actions = new ActionCreator(fetcher);
 
 describe("actions", () => {
-  describe("fetchCollection", () => {
-    let collectionUrl = "http://example.com/feed";
+  describe("fetchBlob", () => {
+    const type = "TEST";
+    const url = "test url";
 
-    it("dispatches request, load, and success", (done) => {
-      let dispatch = stub();
+    it("dispatches request and success", async () => {
+      const dispatch = stub();
       fetcher.resolve = true;
+      fetcher.testData = { blob: () => "blob", ok: true };
 
-      actions.fetchCollection(collectionUrl)(dispatch).then(data => {
-        expect(dispatch.callCount).to.equal(3);
-        expect(dispatch.args[0][0].type).to.equal(ActionCreator.COLLECTION_REQUEST);
-        expect(dispatch.args[1][0].type).to.equal(ActionCreator.COLLECTION_SUCCESS);
-        expect(dispatch.args[2][0].type).to.equal(ActionCreator.COLLECTION_LOAD);
-        expect(data).to.equal(testData);
-        done();
-      }).catch(err => { console.log(err); throw(err); });
+      const data = await actions.fetchBlob(type, url)(dispatch);
+      expect(dispatch.callCount).to.equal(2);
+      expect(dispatch.args[0][0].type).to.equal(`${type}_${ActionCreator.REQUEST}`);
+      expect(dispatch.args[1][0].type).to.equal(`${type}_${ActionCreator.SUCCESS}`);
+      expect(data).to.equal("blob");
     });
 
-    it("dispatches failure", (done) => {
+    it("dispatches failure on bad response", async () => {
+      const dispatch = stub();
+      fetcher.resolve = true;
+      fetcher.testData = { ok: false, status: 500 };
+
+      try {
+        await actions.fetchBlob(type, url)(dispatch);
+        // shouldn't get here
+        expect(false).to.equal(true);
+      } catch (err) {
+        expect(dispatch.callCount).to.equal(2);
+        expect(dispatch.args[0][0].type).to.equal(`${type}_${ActionCreator.REQUEST}`);
+        expect(dispatch.args[1][0].type).to.equal(`${type}_${ActionCreator.FAILURE}`);
+        const expectedError = {
+          status: 500,
+          response: "Request failed",
+          url: url
+        };
+        expect(dispatch.args[1][0].error).to.deep.equal(expectedError);
+        expect(err).to.deep.equal(expectedError);
+      }
+    });
+
+    it("dispatches failure on no response", async () => {
       let dispatch = stub();
       fetcher.resolve = false;
 
-      actions.fetchCollection(collectionUrl)(dispatch).catch(err => {
+      try {
+        await actions.fetchBlob(type, url)(dispatch);
+        // shouldn't get here
+        expect(false).to.equal(true);
+      } catch (err) {
         expect(dispatch.callCount).to.equal(2);
-        expect(dispatch.args[0][0].type).to.equal(ActionCreator.COLLECTION_REQUEST);
-        expect(dispatch.args[1][0].type).to.equal(ActionCreator.COLLECTION_FAILURE);
+        expect(dispatch.args[0][0].type).to.equal(`${type}_${ActionCreator.REQUEST}`);
+        expect(dispatch.args[1][0].type).to.equal(`${type}_${ActionCreator.FAILURE}`);
+        const expectedError = "test error";
+        expect(dispatch.args[1][0].error).to.equal(expectedError);
+        expect(err).to.equal(expectedError);
+      }
+    });
+  });
+
+  describe("fetchJSON", () => {
+    const type = "TEST";
+    const url = "test url";
+
+    it("dispatches request, load, and success", async () => {
+      const dispatch = stub();
+      fetcher.resolve = true;
+      const jsonResponse = new Promise<{ test: number }>(resolve => resolve({ test : 1 }));
+      fetcher.testData = { json: () => jsonResponse, ok: true };
+
+      const data = await actions.fetchJSON<{ test: number }>(type, url)(dispatch);
+      expect(dispatch.callCount).to.equal(3);
+      expect(dispatch.args[0][0].type).to.equal(`${type}_${ActionCreator.REQUEST}`);
+      expect(dispatch.args[1][0].type).to.equal(`${type}_${ActionCreator.SUCCESS}`);
+      expect(dispatch.args[2][0].type).to.equal(`${type}_${ActionCreator.LOAD}`);
+      expect(dispatch.args[2][0].data).to.deep.equal({ test: 1 });
+      expect(data).to.deep.equal({ test: 1 });
+    });
+
+    it("dispatches failure on non-json response", async () => {
+      const dispatch = stub();
+      fetcher.resolve = true;
+      const jsonResponse = new Promise<{ test: number }>((_, reject) => reject());
+      fetcher.testData = { json: () => jsonResponse, ok: true };
+
+      try {
+        await actions.fetchJSON<{ test: number }>(type, url)(dispatch);
+        // shouldn't get here
+        expect(false).to.equal(true);
+      } catch (err) {
+        expect(dispatch.callCount).to.equal(2);
+        expect(dispatch.args[0][0].type).to.equal(`${type}_${ActionCreator.REQUEST}`);
+        expect(dispatch.args[1][0].type).to.equal(`${type}_${ActionCreator.FAILURE}`);
+      }
+    });
+
+    it("dispatches failure on bad response with problem detail", async () => {
+      const dispatch = stub();
+      fetcher.resolve = true;
+      const problemDetail = new Promise<{ detail: string }>(resolve => resolve({ detail : "detail" }));
+      fetcher.testData = { ok: false, status: 500,  json: () => problemDetail };
+
+      try {
+        await actions.fetchJSON<{ test: number }>(type, url)(dispatch);
+        // shouldn't get here
+        expect(false).to.equal(true);
+      } catch (err) {
+        expect(dispatch.callCount).to.equal(2);
+        expect(dispatch.args[0][0].type).to.equal(`${type}_${ActionCreator.REQUEST}`);
+        expect(dispatch.args[1][0].type).to.equal(`${type}_${ActionCreator.FAILURE}`);
+        const expectedError = {
+          status: 500,
+          response: "detail",
+          url: url
+        };
+        expect(dispatch.args[1][0].error).to.deep.equal(expectedError);
+        expect(err).to.deep.equal(expectedError);
+      }
+    });
+
+    it("dispatches failure on bad response without problem detail", async () => {
+      const dispatch = stub();
+      fetcher.resolve = true;
+      const notAProblemDetail = new Promise<{ detail: string }>((_, reject) => reject());
+      fetcher.testData = { ok: false, status: 500,  json: () => notAProblemDetail };
+
+      try {
+        await actions.fetchJSON<{ test: number }>(type, url)(dispatch);
+        // shouldn't get here
+        expect(false).to.equal(true);
+      } catch (err) {
+        expect(dispatch.callCount).to.equal(2);
+        expect(dispatch.args[0][0].type).to.equal(`${type}_${ActionCreator.REQUEST}`);
+        expect(dispatch.args[1][0].type).to.equal(`${type}_${ActionCreator.FAILURE}`);
+        const expectedError = {
+          status: 500,
+          response: "Request failed",
+          url: url
+        };
+        expect(dispatch.args[1][0].error).to.deep.equal(expectedError);
+        expect(err).to.deep.equal(expectedError);
+      }
+    });
+
+    it("dispatches failure on no response", async () => {
+      let dispatch = stub();
+      fetcher.resolve = false;
+      fetcher.testError = { message : "test error" };
+
+      try {
+        await actions.fetchJSON<{ test: number }>(type, url)(dispatch);
+        // shouldn't get here
+        expect(false).to.equal(true);
+      } catch (err) {
+        expect(dispatch.callCount).to.equal(2);
+        expect(dispatch.args[0][0].type).to.equal(`${type}_${ActionCreator.REQUEST}`);
+        expect(dispatch.args[1][0].type).to.equal(`${type}_${ActionCreator.FAILURE}`);
+        const expectedError = {
+          status: null,
+          response: "test error",
+          url: url
+        };
+        expect(dispatch.args[1][0].error).to.deep.equal(expectedError);
+        expect(err).to.deep.equal(expectedError);
+      }
+    });
+  });
+
+  describe("fetchOPDS", () => {
+    const type = "TEST";
+    const url = "test url";
+
+    it("dispatches request, success, and load", async () => {
+      const dispatch = stub();
+      fetcher.resolve = true;
+      fetcher.testData = testData;
+
+      const data = await actions.fetchOPDS<CollectionData>(type, url)(dispatch);
+      expect(dispatch.callCount).to.equal(3);
+      expect(dispatch.args[0][0].type).to.equal(`${type}_${ActionCreator.REQUEST}`);
+      expect(dispatch.args[1][0].type).to.equal(`${type}_${ActionCreator.SUCCESS}`);
+      expect(dispatch.args[2][0].type).to.equal(`${type}_${ActionCreator.LOAD}`);
+      expect(data).to.deep.equal(testData);
+    });
+
+    it("dispatches failure on bad response", async () => {
+      const dispatch = stub();
+      fetcher.resolve = false;
+      fetcher.testError = "test error";
+
+      try {
+        await actions.fetchOPDS<CollectionData>(type, url)(dispatch);
+        // shouldn't get here
+        expect(false).to.equal(true);
+      } catch (err) {
+        expect(dispatch.callCount).to.equal(2);
+        expect(dispatch.args[0][0].type).to.equal(`${type}_${ActionCreator.REQUEST}`);
+        expect(dispatch.args[1][0].type).to.equal(`${type}_${ActionCreator.FAILURE}`);
+        expect(dispatch.args[1][0].error).to.equal("test error");
         expect(err).to.equal("test error");
-        done();
-      }).catch(err => { console.log(err); throw(err); });
+      }
+    });
+  });
+
+  describe("fetchCollection", () => {
+    it("dispatches request, load, and success", async () => {
+      let dispatch = stub();
+      fetcher.resolve = true;
+      fetcher.testData = testData;
+
+      const data = await actions.fetchCollection("http://example.com/feed")(dispatch);
+      expect(dispatch.callCount).to.equal(3);
+      expect(dispatch.args[0][0].type).to.equal(ActionCreator.COLLECTION_REQUEST);
+      expect(dispatch.args[1][0].type).to.equal(ActionCreator.COLLECTION_SUCCESS);
+      expect(dispatch.args[2][0].type).to.equal(ActionCreator.COLLECTION_LOAD);
+      expect(data).to.equal(testData);
     });
   });
 
   describe("fetchPage", () => {
-
-    it("dispatches request, success, and load", (done) => {
+    it("dispatches request, success, and load", async () => {
       let dispatch = stub();
       fetcher.resolve = true;
+      fetcher.testData = testData;
 
-      actions.fetchPage("http://example.com/feed")(dispatch).then(data => {
-        expect(dispatch.callCount).to.equal(3);
-        expect(dispatch.args[0][0].type).to.equal(ActionCreator.PAGE_REQUEST);
-        expect(dispatch.args[1][0].type).to.equal(ActionCreator.PAGE_SUCCESS);
-        expect(dispatch.args[2][0].type).to.equal(ActionCreator.PAGE_LOAD);
-        expect(data).to.equal(testData);
-        done();
-      }).catch(err => { console.log(err); throw(err); });
-    });
-
-    it("dispatches failure", (done) => {
-      let dispatch = stub();
-      fetcher.resolve = false;
-
-      actions.fetchPage("http://example.com/feed")(dispatch).catch(err => {
-        expect(dispatch.callCount).to.equal(2);
-        expect(dispatch.args[0][0].type).to.equal(ActionCreator.PAGE_REQUEST);
-        expect(dispatch.args[1][0].type).to.equal(ActionCreator.PAGE_FAILURE);
-        expect(err).to.equal("test error");
-        done();
-      }).catch(err => { console.log(err); throw(err); });
+      const data = await actions.fetchPage("http://example.com/feed")(dispatch);
+      expect(dispatch.callCount).to.equal(3);
+      expect(dispatch.args[0][0].type).to.equal(ActionCreator.PAGE_REQUEST);
+      expect(dispatch.args[1][0].type).to.equal(ActionCreator.PAGE_SUCCESS);
+      expect(dispatch.args[2][0].type).to.equal(ActionCreator.PAGE_LOAD);
+      expect(data).to.equal(testData);
     });
   });
 
   describe("fetchSearchDescription", () => {
-    it("dispatches load", (done) => {
+    it("dispatches load", async () => {
       let dispatch = stub();
       fetcher.resolve = true;
+      fetcher.testData = testData;
 
-      actions.fetchSearchDescription("http://example.com/search")(dispatch).then(data => {
-        expect(dispatch.callCount).to.equal(1);
-        expect(dispatch.args[0][0].type).to.equal(ActionCreator.SEARCH_DESCRIPTION_LOAD);
-        expect(data).to.equal(testData);
-        done();
-      }).catch(err => { console.log(err); throw(err); });
+      const data = await actions.fetchSearchDescription("http://example.com/search")(dispatch);
+      expect(dispatch.callCount).to.equal(1);
+      expect(dispatch.args[0][0].type).to.equal(ActionCreator.SEARCH_DESCRIPTION_LOAD);
+      expect(data).to.equal(testData);
     });
   });
 
   describe("fetchBook", () => {
-    let bookUrl = "http://example.com/book";
-
-    it("dispatches request, load, and success", (done) => {
+    it("dispatches request, load, and success", async () => {
       let dispatch = stub();
       fetcher.resolve = true;
+      fetcher.testData = testData;
 
-      actions.fetchBook(bookUrl)(dispatch).then(data => {
-        expect(dispatch.callCount).to.equal(3);
-        expect(dispatch.args[0][0].type).to.equal(ActionCreator.BOOK_REQUEST);
-        expect(dispatch.args[1][0].type).to.equal(ActionCreator.BOOK_SUCCESS);
-        expect(dispatch.args[2][0].type).to.equal(ActionCreator.BOOK_LOAD);
-        expect(data).to.equal(testData);
-        done();
-      }).catch(err => { console.log(err); throw(err); });
-    });
-
-    it("dispatches failure", (done) => {
-      let dispatch = stub();
-      fetcher.resolve = false;
-
-      actions.fetchBook(bookUrl)(dispatch).catch(err => {
-        expect(dispatch.callCount).to.equal(2);
-        expect(dispatch.args[0][0].type).to.equal(ActionCreator.BOOK_REQUEST);
-        expect(dispatch.args[1][0].type).to.equal(ActionCreator.BOOK_FAILURE);
-        expect(err).to.equal("test error");
-        done();
-      }).catch(err => { console.log(err); throw(err); });
+      const data = await actions.fetchBook("http://example.com/book")(dispatch);
+      expect(dispatch.callCount).to.equal(3);
+      expect(dispatch.args[0][0].type).to.equal(ActionCreator.BOOK_REQUEST);
+      expect(dispatch.args[1][0].type).to.equal(ActionCreator.BOOK_SUCCESS);
+      expect(dispatch.args[2][0].type).to.equal(ActionCreator.BOOK_LOAD);
+      expect(data).to.equal(testData);
     });
   });
 
@@ -129,63 +284,33 @@ describe("actions", () => {
     let fulfillmentUrl = "http://example.com/book/fulfill";
     let mimeType = "mime/type";
 
-    it("dispatches request, load, and success", (done) => {
+    it("dispatches request, load, and success", async () => {
       let dispatch = stub();
       fetcher.resolve = true;
       fetcher.testData = { fulfillmentUrl, mimeType };
 
-      actions.updateBook(borrowUrl)(dispatch).then(data => {
-        expect(dispatch.callCount).to.equal(3);
-        expect(dispatch.args[0][0].type).to.equal(ActionCreator.UPDATE_BOOK_REQUEST);
-        expect(dispatch.args[1][0].type).to.equal(ActionCreator.UPDATE_BOOK_SUCCESS);
-        expect(dispatch.args[2][0].type).to.equal(ActionCreator.UPDATE_BOOK_LOAD);
-        expect(data).to.equal(fetcher.testData);
-        done();
-      }).catch(err => { console.log(err); throw(err); });
-    });
-
-    it("dispatches failure", (done) => {
-      let dispatch = stub();
-      fetcher.resolve = false;
-
-      actions.updateBook(borrowUrl)(dispatch).catch(err => {
-        expect(dispatch.callCount).to.equal(2);
-        expect(dispatch.args[0][0].type).to.equal(ActionCreator.UPDATE_BOOK_REQUEST);
-        expect(dispatch.args[1][0].type).to.equal(ActionCreator.UPDATE_BOOK_FAILURE);
-        expect(err).to.equal("test error");
-        done();
-      }).catch(err => { console.log(err); throw(err); });
+      const data = await actions.updateBook(borrowUrl)(dispatch);
+      expect(dispatch.callCount).to.equal(3);
+      expect(dispatch.args[0][0].type).to.equal(ActionCreator.UPDATE_BOOK_REQUEST);
+      expect(dispatch.args[1][0].type).to.equal(ActionCreator.UPDATE_BOOK_SUCCESS);
+      expect(dispatch.args[2][0].type).to.equal(ActionCreator.UPDATE_BOOK_LOAD);
+      expect(data).to.equal(fetcher.testData);
     });
   });
 
   describe("fulfillBook", () => {
     let fulfillmentUrl = "http://example.com/book/fulfill";
 
-    it("dispatches request, load, and success", (done) => {
+    it("dispatches request, load, and success", async () => {
       let dispatch = stub();
       fetcher.resolve = true;
       fetcher.testData = { blob: () => "blob", ok: true };
 
-      actions.fulfillBook(fulfillmentUrl)(dispatch).then(data => {
-        expect(dispatch.callCount).to.equal(2);
-        expect(dispatch.args[0][0].type).to.equal(ActionCreator.FULFILL_BOOK_REQUEST);
-        expect(dispatch.args[1][0].type).to.equal(ActionCreator.FULFILL_BOOK_SUCCESS);
-        expect(data).to.equal("blob");
-        done();
-      }).catch(err => { console.log(err); throw(err); });
-    });
-
-    it("dispatches failure", (done) => {
-      let dispatch = stub();
-      fetcher.resolve = false;
-
-      actions.fulfillBook(fulfillmentUrl)(dispatch).catch(err => {
-        expect(dispatch.callCount).to.equal(2);
-        expect(dispatch.args[0][0].type).to.equal(ActionCreator.FULFILL_BOOK_REQUEST);
-        expect(dispatch.args[1][0].type).to.equal(ActionCreator.FULFILL_BOOK_FAILURE);
-        expect(err).to.equal("test error");
-        done();
-      }).catch(err => { console.log(err); throw(err); });
+      const data = await actions.fulfillBook(fulfillmentUrl)(dispatch);
+      expect(dispatch.callCount).to.equal(2);
+      expect(dispatch.args[0][0].type).to.equal(ActionCreator.FULFILL_BOOK_REQUEST);
+      expect(dispatch.args[1][0].type).to.equal(ActionCreator.FULFILL_BOOK_SUCCESS);
+      expect(data).to.equal("blob");
     });
   });
 
@@ -194,7 +319,7 @@ describe("actions", () => {
     let fulfillmentType = "text/html;profile=http://librarysimplified.org/terms/profiles/streaming-media";
     let indirectUrl = "http://example.com/reader";
 
-    it("dispatches request, load, and success", (done) => {
+    it("dispatches request, load, and success", async () => {
       let dispatch = stub();
       fetcher.resolve = true;
       fetcher.testData = {
@@ -203,58 +328,28 @@ describe("actions", () => {
         ]
       };
 
-      actions.indirectFulfillBook(fulfillmentUrl, fulfillmentType)(dispatch).then(url => {
-        expect(dispatch.callCount).to.equal(2);
-        expect(dispatch.args[0][0].type).to.equal(ActionCreator.FULFILL_BOOK_REQUEST);
-        expect(dispatch.args[1][0].type).to.equal(ActionCreator.FULFILL_BOOK_SUCCESS);
-        expect(url).to.equal(indirectUrl);
-        done();
-      }).catch(err => { console.log(err); throw(err); });
-    });
-
-    it("dispatches failure", (done) => {
-      let dispatch = stub();
-      fetcher.resolve = false;
-
-      actions.indirectFulfillBook(fulfillmentUrl, fulfillmentType)(dispatch).catch(err => {
-        expect(dispatch.callCount).to.equal(2);
-        expect(dispatch.args[0][0].type).to.equal(ActionCreator.FULFILL_BOOK_REQUEST);
-        expect(dispatch.args[1][0].type).to.equal(ActionCreator.FULFILL_BOOK_FAILURE);
-        expect(err).to.equal("test error");
-        done();
-      }).catch(err => { console.log(err); throw(err); });
+      const url = await actions.indirectFulfillBook(fulfillmentUrl, fulfillmentType)(dispatch);
+      expect(dispatch.callCount).to.equal(2);
+      expect(dispatch.args[0][0].type).to.equal(ActionCreator.FULFILL_BOOK_REQUEST);
+      expect(dispatch.args[1][0].type).to.equal(ActionCreator.FULFILL_BOOK_SUCCESS);
+      expect(url).to.equal(indirectUrl);
     });
   });
 
   describe("fetchLoans", () => {
     let loansUrl = "http://example.com/loans";
 
-    it("dispatches request, load, and success", (done) => {
+    it("dispatches request, load, and success", async () => {
       let dispatch = stub();
       fetcher.resolve = true;
       fetcher.testData = testData;
 
-      actions.fetchLoans(loansUrl)(dispatch).then(data => {
-        expect(dispatch.callCount).to.equal(3);
-        expect(dispatch.args[0][0].type).to.equal(ActionCreator.LOANS_REQUEST);
-        expect(dispatch.args[1][0].type).to.equal(ActionCreator.LOANS_SUCCESS);
-        expect(dispatch.args[2][0].type).to.equal(ActionCreator.LOANS_LOAD);
-        expect(data).to.equal(testData);
-        done();
-      }).catch(err => { console.log(err); throw(err); });
-    });
-
-    it("dispatches failure", (done) => {
-      let dispatch = stub();
-      fetcher.resolve = false;
-
-      actions.fetchLoans(loansUrl)(dispatch).catch(err => {
-        expect(dispatch.callCount).to.equal(2);
-        expect(dispatch.args[0][0].type).to.equal(ActionCreator.LOANS_REQUEST);
-        expect(dispatch.args[1][0].type).to.equal(ActionCreator.LOANS_FAILURE);
-        expect(err).to.equal("test error");
-        done();
-      }).catch(err => { console.log(err); throw(err); });
+      const data = await actions.fetchLoans(loansUrl)(dispatch);
+      expect(dispatch.callCount).to.equal(3);
+      expect(dispatch.args[0][0].type).to.equal(ActionCreator.LOANS_REQUEST);
+      expect(dispatch.args[1][0].type).to.equal(ActionCreator.LOANS_SUCCESS);
+      expect(dispatch.args[2][0].type).to.equal(ActionCreator.LOANS_LOAD);
+      expect(data).to.equal(testData);
     });
   });
 

--- a/packages/opds-web-client/src/actions.ts
+++ b/packages/opds-web-client/src/actions.ts
@@ -4,48 +4,62 @@ import {
   AuthCallback, AuthCredentials, AuthProvider, AuthMethod
 } from "./interfaces";
 
-export interface LoadCollectionAction {
+export interface LoadAction<T> {
   type: string;
-  data: CollectionData;
+  data: T;
   url?: string;
 }
 
 export default class ActionCreator {
   private fetcher: DataFetcher;
 
-  static readonly FETCH_COLLECTION_REQUEST = "FETCH_COLLECTION_REQUEST";
-  static readonly FETCH_COLLECTION_SUCCESS = "FETCH_COLLECTION_SUCCESS";
-  static readonly FETCH_COLLECTION_FAILURE = "FETCH_COLLECTION_FAILURE";
-  static readonly LOAD_COLLECTION = "LOAD_COLLECTION";
-  static readonly CLEAR_COLLECTION = "CLEAR_COLLECTION";
+  static readonly REQUEST = "REQUEST";
+  static readonly SUCCESS = "SUCCESS";
+  static readonly FAILURE = "FAILURE";
+  static readonly LOAD = "LOAD";
+  static readonly CLEAR = "CLEAR";
 
-  static readonly FETCH_PAGE_REQUEST = "FETCH_PAGE_REQUEST";
-  static readonly FETCH_PAGE_SUCCESS = "FETCH_PAGE_SUCCESS";
-  static readonly FETCH_PAGE_FAILURE = "FETCH_PAGE_FAILURE";
-  static readonly LOAD_PAGE = "LOAD_PAGE";
+  static readonly COLLECTION = "COLLECTION";
+  static readonly PAGE = "PAGE";
+  static readonly BOOK = "BOOK";
+  static readonly SEARCH_DESCRIPTION = "SEARCH_DESCRIPTION";
+  static readonly UPDATE_BOOK = "UPDATE_BOOK";
+  static readonly FULFILL_BOOK = "FULFILL_BOOK";
+  static readonly LOANS = "LOANS";
 
-  static readonly FETCH_BOOK_REQUEST = "FETCH_BOOK_REQUEST";
-  static readonly FETCH_BOOK_SUCCESS = "FETCH_BOOK_SUCCESS";
-  static readonly FETCH_BOOK_FAILURE = "FETCH_BOOK_FAILURE";
-  static readonly LOAD_BOOK = "LOAD_BOOK";
-  static readonly CLEAR_BOOK = "CLEAR_BOOK";
+  static readonly COLLECTION_REQUEST = "COLLECTION_REQUEST";
+  static readonly COLLECTION_SUCCESS = "COLLECTION_SUCCESS";
+  static readonly COLLECTION_FAILURE = "COLLECTION_FAILURE";
+  static readonly COLLECTION_LOAD = "COLLECTION_LOAD";
+  static readonly COLLECTION_CLEAR = "COLLECTION_CLEAR";
 
-  static readonly LOAD_SEARCH_DESCRIPTION = "LOAD_SEARCH_DESCRIPTION";
+  static readonly PAGE_REQUEST = "PAGE_REQUEST";
+  static readonly PAGE_SUCCESS = "PAGE_SUCCESS";
+  static readonly PAGE_FAILURE = "PAGE_FAILURE";
+  static readonly PAGE_LOAD = "PAGE_LOAD";
+
+  static readonly BOOK_REQUEST = "BOOK_REQUEST";
+  static readonly BOOK_SUCCESS = "BOOK_SUCCESS";
+  static readonly BOOK_FAILURE = "BOOK_FAILURE";
+  static readonly BOOK_LOAD = "BOOK_LOAD";
+  static readonly BOOK_CLEAR = "BOOK_CLEAR";
+
+  static readonly SEARCH_DESCRIPTION_LOAD = "SEARCH_DESCRIPTION_LOAD";
   static readonly CLOSE_ERROR = "CLOSE_ERROR";
 
   static readonly UPDATE_BOOK_REQUEST = "UPDATE_BOOK_REQUEST";
   static readonly UPDATE_BOOK_SUCCESS = "UPDATE_BOOK_SUCCESS";
   static readonly UPDATE_BOOK_FAILURE = "UPDATE_BOOK_FAILURE";
-  static readonly LOAD_UPDATE_BOOK_DATA = "LOAD_UPDATE_BOOK_DATA";
+  static readonly UPDATE_BOOK_LOAD = "UPDATE_BOOK_LOAD";
 
   static readonly FULFILL_BOOK_REQUEST = "FULFILL_BOOK_REQUEST";
   static readonly FULFILL_BOOK_SUCCESS = "FULFILL_BOOK_SUCCESS";
   static readonly FULFILL_BOOK_FAILURE = "FULFILL_BOOK_FAILURE";
 
-  static readonly FETCH_LOANS_REQUEST = "FETCH_LOANS_REQUEST";
-  static readonly FETCH_LOANS_SUCCESS = "FETCH_LOANS_SUCCESS";
-  static readonly FETCH_LOANS_FAILURE = "FETCH_LOANS_FAILURE";
-  static readonly LOAD_LOANS = "LOAD_LOANS";
+  static readonly LOANS_REQUEST = "LOANS_REQUEST";
+  static readonly LOANS_SUCCESS = "LOANS_SUCCESS";
+  static readonly LOANS_FAILURE = "LOANS_FAILURE";
+  static readonly LOANS_LOAD = "LOANS_LOAD";
 
   static readonly SHOW_AUTH_FORM = "SHOW_AUTH_FORM";
   static readonly HIDE_AUTH_FORM = "HIDE_AUTH_FORM";
@@ -56,200 +70,127 @@ export default class ActionCreator {
     this.fetcher = fetcher;
   }
 
-  fetchCollection(url: string) {
-    return (dispatch): Promise<CollectionData> => {
-      dispatch(this.fetchCollectionRequest(url));
-      return new Promise((resolve, reject) => {
-        this.fetcher.fetchOPDSData(url).then((data: CollectionData) => {
-          dispatch(this.fetchCollectionSuccess());
-          dispatch(this.loadCollection(data, url));
-          resolve(data);
+
+  fetch(type: string, url?: string) {
+    return (dispatch): Promise<Blob> => {
+      dispatch(this.request(type, url));
+      return new Promise<Blob>((resolve, reject) => {
+        this.fetcher.fetch(url).then(response => {
+          if (response.ok) {
+            return response.blob();
+          } else {
+            throw({
+              status: response.status,
+              response: "Request failed",
+              url: url
+            });
+          }
+        }).then(blob => {
+          dispatch(this.success(type));
+          resolve(blob);
         }).catch(err => {
-          dispatch(this.fetchCollectionFailure(err));
+          dispatch(this.failure(type, err));
           reject(err);
         });
       });
     };
+  }
+
+  fetchOPDS<T>(type: string, url?: string) {
+    return (dispatch): Promise<T> => {
+      dispatch(this.request(type, url));
+      return new Promise<T>((resolve, reject) => {
+        this.fetcher.fetchOPDSData(url).then((data: T) => {
+          dispatch(this.success(type));
+          dispatch(this.load<T>(type, data, url));
+          resolve(data);
+        }).catch(err => {
+          dispatch(this.failure(type, err));
+          reject(err);
+        });
+      });
+    };
+  }
+
+  request(type: string, url?: string) {
+    return { type: `${type}_${ActionCreator.REQUEST}`, url: url };
+  }
+
+  success(type: string) {
+    return { type: `${type}_${ActionCreator.SUCCESS}` };
+  }
+
+  failure(type: string, error?: FetchErrorData) {
+    return { type: `${type}_${ActionCreator.FAILURE}`, error };
+  }
+
+  load<T>(type: string, data: T, url?: string): LoadAction<T> {
+    return { type: `${type}_${ActionCreator.LOAD}`, data, url };
+  }
+
+  clear(type: string) {
+    return { type: `${type}_${ActionCreator.CLEAR}` };
+  }
+
+
+  fetchCollection(url: string) {
+    return this.fetchOPDS<CollectionData>(ActionCreator.COLLECTION, url);
   }
 
   fetchPage(url: string) {
-    return (dispatch) => {
-      dispatch(this.fetchPageRequest(url));
-      return new Promise((resolve, reject) => {
-        this.fetcher.fetchOPDSData(url).then((data: CollectionData) => {
-          dispatch(this.fetchPageSuccess());
-          dispatch(this.loadPage(data));
-          resolve(data);
-        }).catch(err => {
-          dispatch(this.fetchPageFailure(err));
-          reject(err);
-        });
-      });
-    };
+    return this.fetchOPDS<CollectionData>(ActionCreator.PAGE, url);
   }
 
   fetchBook(url: string) {
-    return (dispatch) => {
-      dispatch(this.fetchBookRequest(url));
-      return new Promise((resolve, reject) => {
-        this.fetcher.fetchOPDSData(url).then((data: BookData) => {
-          dispatch(this.fetchBookSuccess());
-          dispatch(this.loadBook(data, url));
-          resolve(data);
-        }).catch(err => {
-          dispatch(this.fetchBookFailure(err));
-          reject(err);
-        });
-      });
-    };
+    return this.fetchOPDS<BookData>(ActionCreator.BOOK, url);
   }
 
   fetchSearchDescription(url: string) {
     return (dispatch) => {
-      return new Promise((resolve, reject) => {
+      return new Promise<SearchData>((resolve, reject) => {
         this.fetcher.fetchSearchDescriptionData(url).then((data: SearchData) => {
-          dispatch(this.loadSearchDescription(data));
+          dispatch(this.load<SearchData>(ActionCreator.SEARCH_DESCRIPTION, data, url));
           resolve(data);
         }).catch(err => reject(err));
       });
     };
   }
 
-  fetchCollectionRequest(url: string) {
-    return { type: ActionCreator.FETCH_COLLECTION_REQUEST, url };
-  }
-
-  fetchCollectionSuccess() {
-    return { type: ActionCreator.FETCH_COLLECTION_SUCCESS };
-  }
-
-  fetchCollectionFailure(error?: FetchErrorData) {
-    return { type: ActionCreator.FETCH_COLLECTION_FAILURE, error };
-  }
-
-  loadCollection(data: CollectionData, url?: string): LoadCollectionAction {
-    return { type: ActionCreator.LOAD_COLLECTION, data, url };
-  }
-
-  fetchPageRequest(url: string) {
-    return { type: ActionCreator.FETCH_PAGE_REQUEST, url };
-  }
-
-  fetchPageSuccess() {
-    return { type: ActionCreator.FETCH_PAGE_SUCCESS };
-  }
-
-  fetchPageFailure(error?: FetchErrorData) {
-    return { type: ActionCreator.FETCH_PAGE_FAILURE, error };
-  }
-
-  loadPage(data: CollectionData) {
-    return { type: ActionCreator.LOAD_PAGE, data };
-  }
-
   clearCollection() {
-    return { type: ActionCreator.CLEAR_COLLECTION };
-  }
-
-  loadSearchDescription(data: SearchData) {
-    return { type: ActionCreator.LOAD_SEARCH_DESCRIPTION, data };
+    return this.clear(ActionCreator.COLLECTION);
   }
 
   closeError() {
     return { type: ActionCreator.CLOSE_ERROR };
   }
 
-  fetchBookRequest(url: string) {
-    return { type: ActionCreator.FETCH_BOOK_REQUEST, url };
-  }
-
-  fetchBookSuccess() {
-    return { type: ActionCreator.FETCH_BOOK_SUCCESS };
-  }
-
-  fetchBookFailure(error?: FetchErrorData) {
-    return { type: ActionCreator.FETCH_BOOK_FAILURE, error };
-  }
-
   loadBook(data: BookData, url: string) {
-    return { type: ActionCreator.LOAD_BOOK, data, url };
+    return this.load<BookData>(ActionCreator.BOOK, data, url);
   }
 
   clearBook() {
-    return { type: ActionCreator.CLEAR_BOOK };
+    return this.clear(ActionCreator.BOOK);
   }
 
   updateBook(url: string): (dispatch: any) => Promise<BookData> {
-    return (dispatch) => {
-      dispatch(this.updateBookRequest());
-      return new Promise((resolve, reject) => {
-        this.fetcher.fetchOPDSData(url).then((data: BookData) => {
-          dispatch(this.updateBookSuccess());
-          dispatch(this.loadUpdateBookData(data));
-          resolve(data);
-        }).catch((err: FetchErrorData) => {
-          dispatch(this.updateBookFailure(err));
-          reject(err);
-        });
-      });
-    };
-  }
-
-  updateBookRequest() {
-    return { type: ActionCreator.UPDATE_BOOK_REQUEST };
-  }
-
-  updateBookSuccess() {
-    return { type: ActionCreator.UPDATE_BOOK_SUCCESS };
-  }
-
-  updateBookFailure(error) {
-    return { type: ActionCreator.UPDATE_BOOK_FAILURE, error };
-  }
-
-  loadUpdateBookData(data) {
-    return { type: ActionCreator.LOAD_UPDATE_BOOK_DATA, data };
+    return this.fetchOPDS<BookData>(ActionCreator.UPDATE_BOOK, url);
   }
 
   fulfillBook(url: string): (dispatch: any) => Promise<Blob> {
-    return (dispatch) => {
-      return new Promise((resolve, reject) => {
-        dispatch(this.fulfillBookRequest());
-        this.fetcher.fetch(url)
-          .then(response => {
-            if (response.ok) {
-              return response.blob();
-            } else {
-              throw({
-                status: response.status,
-                response: "Could not fulfill book",
-                url: url
-              });
-            }
-          })
-          .then(blob => {
-            dispatch(this.fulfillBookSuccess());
-            resolve(blob);
-          })
-          .catch(err => {
-            dispatch(this.fulfillBookFailure(err));
-            reject(err);
-          });
-      });
-    };
+    return this.fetch(ActionCreator.FULFILL_BOOK, url);
   }
 
   indirectFulfillBook(url: string, type: string): (dispatch: any) => Promise<string> {
     return (dispatch) => {
-      return new Promise((resolve, reject) => {
-        dispatch(this.fulfillBookRequest());
+      return new Promise<string>((resolve, reject) => {
+        dispatch(this.request(ActionCreator.FULFILL_BOOK, url));
         this.fetcher.fetchOPDSData(url).then((book: BookData) => {
           let link = book.fulfillmentLinks.find(link =>
             link.type === type
           );
 
           if (link) {
-            dispatch(this.fulfillBookSuccess());
+            dispatch(this.success(ActionCreator.FULFILL_BOOK));
             resolve(link.url);
           } else {
             throw({
@@ -259,55 +200,15 @@ export default class ActionCreator {
             });
           }
         }).catch(err => {
-          dispatch(this.fulfillBookFailure(err));
+          dispatch(this.failure(ActionCreator.FULFILL_BOOK, err));
           reject(err);
         });
       });
     };
-  }
-
-  fulfillBookRequest() {
-    return { type: ActionCreator.FULFILL_BOOK_REQUEST };
-  }
-
-  fulfillBookSuccess() {
-    return { type: ActionCreator.FULFILL_BOOK_SUCCESS };
-  }
-
-  fulfillBookFailure(error) {
-    return { type: ActionCreator.FULFILL_BOOK_FAILURE, error };
   }
 
   fetchLoans(url: string) {
-    return (dispatch) => {
-      dispatch(this.fetchLoansRequest(url));
-      return new Promise((resolve, reject) => {
-        this.fetcher.fetchOPDSData(url).then((data: CollectionData) => {
-          dispatch(this.fetchLoansSuccess());
-          dispatch(this.loadLoans(data.books));
-          resolve(data);
-        }).catch(err => {
-          dispatch(this.fetchLoansFailure(err));
-          reject(err);
-        });
-      });
-    };
-  }
-
-  fetchLoansRequest(url: string) {
-    return { type: ActionCreator.FETCH_LOANS_REQUEST, url };
-  }
-
-  fetchLoansSuccess() {
-    return { type: ActionCreator.FETCH_LOANS_SUCCESS };
-  }
-
-  fetchLoansFailure(error?: FetchErrorData) {
-    return { type: ActionCreator.FETCH_LOANS_FAILURE, error };
-  }
-
-  loadLoans(books: BookData[]) {
-    return { type: ActionCreator.LOAD_LOANS, books };
+    return this.fetchOPDS<CollectionData>(ActionCreator.LOANS, url);
   }
 
   showAuthForm(

--- a/packages/opds-web-client/src/actions.ts
+++ b/packages/opds-web-client/src/actions.ts
@@ -13,44 +13,44 @@ export interface LoadCollectionAction {
 export default class ActionCreator {
   private fetcher: DataFetcher;
 
-  FETCH_COLLECTION_REQUEST = "FETCH_COLLECTION_REQUEST";
-  FETCH_COLLECTION_SUCCESS = "FETCH_COLLECTION_SUCCESS";
-  FETCH_COLLECTION_FAILURE = "FETCH_COLLECTION_FAILURE";
-  LOAD_COLLECTION = "LOAD_COLLECTION";
-  CLEAR_COLLECTION = "CLEAR_COLLECTION";
+  static readonly FETCH_COLLECTION_REQUEST = "FETCH_COLLECTION_REQUEST";
+  static readonly FETCH_COLLECTION_SUCCESS = "FETCH_COLLECTION_SUCCESS";
+  static readonly FETCH_COLLECTION_FAILURE = "FETCH_COLLECTION_FAILURE";
+  static readonly LOAD_COLLECTION = "LOAD_COLLECTION";
+  static readonly CLEAR_COLLECTION = "CLEAR_COLLECTION";
 
-  FETCH_PAGE_REQUEST = "FETCH_PAGE_REQUEST";
-  FETCH_PAGE_SUCCESS = "FETCH_PAGE_SUCCESS";
-  FETCH_PAGE_FAILURE = "FETCH_PAGE_FAILURE";
-  LOAD_PAGE = "LOAD_PAGE";
+  static readonly FETCH_PAGE_REQUEST = "FETCH_PAGE_REQUEST";
+  static readonly FETCH_PAGE_SUCCESS = "FETCH_PAGE_SUCCESS";
+  static readonly FETCH_PAGE_FAILURE = "FETCH_PAGE_FAILURE";
+  static readonly LOAD_PAGE = "LOAD_PAGE";
 
-  FETCH_BOOK_REQUEST = "FETCH_BOOK_REQUEST";
-  FETCH_BOOK_SUCCESS = "FETCH_BOOK_SUCCESS";
-  FETCH_BOOK_FAILURE = "FETCH_BOOK_FAILURE";
-  LOAD_BOOK = "LOAD_BOOK";
-  CLEAR_BOOK = "CLEAR_BOOK";
+  static readonly FETCH_BOOK_REQUEST = "FETCH_BOOK_REQUEST";
+  static readonly FETCH_BOOK_SUCCESS = "FETCH_BOOK_SUCCESS";
+  static readonly FETCH_BOOK_FAILURE = "FETCH_BOOK_FAILURE";
+  static readonly LOAD_BOOK = "LOAD_BOOK";
+  static readonly CLEAR_BOOK = "CLEAR_BOOK";
 
-  LOAD_SEARCH_DESCRIPTION = "LOAD_SEARCH_DESCRIPTION";
-  CLOSE_ERROR = "CLOSE_ERROR";
+  static readonly LOAD_SEARCH_DESCRIPTION = "LOAD_SEARCH_DESCRIPTION";
+  static readonly CLOSE_ERROR = "CLOSE_ERROR";
 
-  UPDATE_BOOK_REQUEST = "UPDATE_BOOK_REQUEST";
-  UPDATE_BOOK_SUCCESS = "UPDATE_BOOK_SUCCESS";
-  UPDATE_BOOK_FAILURE = "UPDATE_BOOK_FAILURE";
-  LOAD_UPDATE_BOOK_DATA = "LOAD_UPDATE_BOOK_DATA";
+  static readonly UPDATE_BOOK_REQUEST = "UPDATE_BOOK_REQUEST";
+  static readonly UPDATE_BOOK_SUCCESS = "UPDATE_BOOK_SUCCESS";
+  static readonly UPDATE_BOOK_FAILURE = "UPDATE_BOOK_FAILURE";
+  static readonly LOAD_UPDATE_BOOK_DATA = "LOAD_UPDATE_BOOK_DATA";
 
-  FULFILL_BOOK_REQUEST = "FULFILL_BOOK_REQUEST";
-  FULFILL_BOOK_SUCCESS = "FULFILL_BOOK_SUCCESS";
-  FULFILL_BOOK_FAILURE = "FULFILL_BOOK_FAILURE";
+  static readonly FULFILL_BOOK_REQUEST = "FULFILL_BOOK_REQUEST";
+  static readonly FULFILL_BOOK_SUCCESS = "FULFILL_BOOK_SUCCESS";
+  static readonly FULFILL_BOOK_FAILURE = "FULFILL_BOOK_FAILURE";
 
-  FETCH_LOANS_REQUEST = "FETCH_LOANS_REQUEST";
-  FETCH_LOANS_SUCCESS = "FETCH_LOANS_SUCCESS";
-  FETCH_LOANS_FAILURE = "FETCH_LOANS_FAILURE";
-  LOAD_LOANS = "LOAD_LOANS";
+  static readonly FETCH_LOANS_REQUEST = "FETCH_LOANS_REQUEST";
+  static readonly FETCH_LOANS_SUCCESS = "FETCH_LOANS_SUCCESS";
+  static readonly FETCH_LOANS_FAILURE = "FETCH_LOANS_FAILURE";
+  static readonly LOAD_LOANS = "LOAD_LOANS";
 
-  SHOW_AUTH_FORM = "SHOW_AUTH_FORM";
-  HIDE_AUTH_FORM = "HIDE_AUTH_FORM";
-  SAVE_AUTH_CREDENTIALS = "SAVE_AUTH_CREDENTIALS";
-  CLEAR_AUTH_CREDENTIALS = "CLEAR_AUTH_CREDENTIALS";
+  static readonly SHOW_AUTH_FORM = "SHOW_AUTH_FORM";
+  static readonly HIDE_AUTH_FORM = "HIDE_AUTH_FORM";
+  static readonly SAVE_AUTH_CREDENTIALS = "SAVE_AUTH_CREDENTIALS";
+  static readonly CLEAR_AUTH_CREDENTIALS = "CLEAR_AUTH_CREDENTIALS";
 
   constructor(fetcher: DataFetcher) {
     this.fetcher = fetcher;
@@ -116,67 +116,67 @@ export default class ActionCreator {
   }
 
   fetchCollectionRequest(url: string) {
-    return { type: this.FETCH_COLLECTION_REQUEST, url };
+    return { type: ActionCreator.FETCH_COLLECTION_REQUEST, url };
   }
 
   fetchCollectionSuccess() {
-    return { type: this.FETCH_COLLECTION_SUCCESS };
+    return { type: ActionCreator.FETCH_COLLECTION_SUCCESS };
   }
 
   fetchCollectionFailure(error?: FetchErrorData) {
-    return { type: this.FETCH_COLLECTION_FAILURE, error };
+    return { type: ActionCreator.FETCH_COLLECTION_FAILURE, error };
   }
 
   loadCollection(data: CollectionData, url?: string): LoadCollectionAction {
-    return { type: this.LOAD_COLLECTION, data, url };
+    return { type: ActionCreator.LOAD_COLLECTION, data, url };
   }
 
   fetchPageRequest(url: string) {
-    return { type: this.FETCH_PAGE_REQUEST, url };
+    return { type: ActionCreator.FETCH_PAGE_REQUEST, url };
   }
 
   fetchPageSuccess() {
-    return { type: this.FETCH_PAGE_SUCCESS };
+    return { type: ActionCreator.FETCH_PAGE_SUCCESS };
   }
 
   fetchPageFailure(error?: FetchErrorData) {
-    return { type: this.FETCH_PAGE_FAILURE, error };
+    return { type: ActionCreator.FETCH_PAGE_FAILURE, error };
   }
 
   loadPage(data: CollectionData) {
-    return { type: this.LOAD_PAGE, data };
+    return { type: ActionCreator.LOAD_PAGE, data };
   }
 
   clearCollection() {
-    return { type: this.CLEAR_COLLECTION };
+    return { type: ActionCreator.CLEAR_COLLECTION };
   }
 
   loadSearchDescription(data: SearchData) {
-    return { type: this.LOAD_SEARCH_DESCRIPTION, data };
+    return { type: ActionCreator.LOAD_SEARCH_DESCRIPTION, data };
   }
 
   closeError() {
-    return { type: this.CLOSE_ERROR };
+    return { type: ActionCreator.CLOSE_ERROR };
   }
 
   fetchBookRequest(url: string) {
-    return { type: this.FETCH_BOOK_REQUEST, url };
+    return { type: ActionCreator.FETCH_BOOK_REQUEST, url };
   }
 
   fetchBookSuccess() {
-    return { type: this.FETCH_BOOK_SUCCESS };
+    return { type: ActionCreator.FETCH_BOOK_SUCCESS };
   }
 
   fetchBookFailure(error?: FetchErrorData) {
-    return { type: this.FETCH_BOOK_FAILURE, error };
+    return { type: ActionCreator.FETCH_BOOK_FAILURE, error };
   }
 
   loadBook(data: BookData, url: string) {
-    return { type: this.LOAD_BOOK, data, url };
+    return { type: ActionCreator.LOAD_BOOK, data, url };
   }
 
   clearBook() {
-    return { type: this.CLEAR_BOOK };
+    return { type: ActionCreator.CLEAR_BOOK };
   }
 
   updateBook(url: string): (dispatch: any) => Promise<BookData> {
@@ -196,19 +196,19 @@ export default class ActionCreator {
   }
 
   updateBookRequest() {
-    return { type: this.UPDATE_BOOK_REQUEST };
+    return { type: ActionCreator.UPDATE_BOOK_REQUEST };
   }
 
   updateBookSuccess() {
-    return { type: this.UPDATE_BOOK_SUCCESS };
+    return { type: ActionCreator.UPDATE_BOOK_SUCCESS };
   }
 
   updateBookFailure(error) {
-    return { type: this.UPDATE_BOOK_FAILURE, error };
+    return { type: ActionCreator.UPDATE_BOOK_FAILURE, error };
   }
 
   loadUpdateBookData(data) {
-    return { type: this.LOAD_UPDATE_BOOK_DATA, data };
+    return { type: ActionCreator.LOAD_UPDATE_BOOK_DATA, data };
   }
 
   fulfillBook(url: string): (dispatch: any) => Promise<Blob> {
@@ -267,15 +267,15 @@ export default class ActionCreator {
   }
 
   fulfillBookRequest() {
-    return { type: this.FULFILL_BOOK_REQUEST };
+    return { type: ActionCreator.FULFILL_BOOK_REQUEST };
   }
 
   fulfillBookSuccess() {
-    return { type: this.FULFILL_BOOK_SUCCESS };
+    return { type: ActionCreator.FULFILL_BOOK_SUCCESS };
   }
 
   fulfillBookFailure(error) {
-    return { type: this.FULFILL_BOOK_FAILURE, error };
+    return { type: ActionCreator.FULFILL_BOOK_FAILURE, error };
   }
 
   fetchLoans(url: string) {
@@ -295,19 +295,19 @@ export default class ActionCreator {
   }
 
   fetchLoansRequest(url: string) {
-    return { type: this.FETCH_LOANS_REQUEST, url };
+    return { type: ActionCreator.FETCH_LOANS_REQUEST, url };
   }
 
   fetchLoansSuccess() {
-    return { type: this.FETCH_LOANS_SUCCESS };
+    return { type: ActionCreator.FETCH_LOANS_SUCCESS };
   }
 
   fetchLoansFailure(error?: FetchErrorData) {
-    return { type: this.FETCH_LOANS_FAILURE, error };
+    return { type: ActionCreator.FETCH_LOANS_FAILURE, error };
   }
 
   loadLoans(books: BookData[]) {
-    return { type: this.LOAD_LOANS, books };
+    return { type: ActionCreator.LOAD_LOANS, books };
   }
 
   showAuthForm(
@@ -318,7 +318,7 @@ export default class ActionCreator {
     error?: string,
     attemptedProvider?: string
   ) {
-    return { type: this.SHOW_AUTH_FORM, callback, cancel, providers, title, error, attemptedProvider };
+    return { type: ActionCreator.SHOW_AUTH_FORM, callback, cancel, providers, title, error, attemptedProvider };
   }
 
   closeErrorAndHideAuthForm() {
@@ -329,16 +329,16 @@ export default class ActionCreator {
   }
 
   hideAuthForm() {
-    return { type: this.HIDE_AUTH_FORM };
+    return { type: ActionCreator.HIDE_AUTH_FORM };
   }
 
   saveAuthCredentials(credentials: AuthCredentials) {
     this.fetcher.setAuthCredentials(credentials);
-    return { type: this.SAVE_AUTH_CREDENTIALS, credentials };
+    return { type: ActionCreator.SAVE_AUTH_CREDENTIALS, credentials };
   }
 
   clearAuthCredentials() {
     this.fetcher.clearAuthCredentials();
-    return { type: this.CLEAR_AUTH_CREDENTIALS };
+    return { type: ActionCreator.CLEAR_AUTH_CREDENTIALS };
   }
 }

--- a/packages/opds-web-client/src/reducers/__tests__/auth-test.ts
+++ b/packages/opds-web-client/src/reducers/__tests__/auth-test.ts
@@ -3,12 +3,12 @@ import { stub } from "sinon";
 
 import reducer from "../auth";
 import DataFetcher from "../../DataFetcher";
-import ActionsCreator from "../../actions";
+import ActionCreator from "../../actions";
 import { adapter } from "../../OPDSDataAdapter";
 import BasicAuthPlugin from "../../BasicAuthPlugin";
 
 let fetcher = new DataFetcher({ adapter });
-let actions = new ActionsCreator(fetcher);
+let actions = new ActionCreator(fetcher);
 
 describe("auth reducer", () => {
   let initState = {

--- a/packages/opds-web-client/src/reducers/__tests__/book-test.ts
+++ b/packages/opds-web-client/src/reducers/__tests__/book-test.ts
@@ -2,11 +2,12 @@ import { expect } from "chai";
 
 import reducer from "../book";
 import DataFetcher from "../../DataFetcher";
-import ActionsCreator from "../../actions";
+import ActionCreator from "../../actions";
 import { adapter } from "../../OPDSDataAdapter";
+import { BookData } from "../../interfaces";
 
 let fetcher = new DataFetcher({ adapter });
-let actions = new ActionsCreator(fetcher);
+let actions = new ActionCreator(fetcher);
 
 describe("book reducer", () => {
   let book = {
@@ -56,8 +57,8 @@ describe("book reducer", () => {
     expect(reducer(undefined, {})).to.deep.equal(initState);
   });
 
-  it("should handle FETCH_BOOK_REQUEST", () => {
-    let action = actions.fetchBookRequest("some other url");
+  it("should handle BOOK_REQUEST", () => {
+    let action = actions.request(ActionCreator.BOOK, "some other url");
     let newState = Object.assign({}, errorState, {
       isFetching: true,
       error: null
@@ -66,8 +67,8 @@ describe("book reducer", () => {
     expect(reducer(errorState, action)).to.deep.equal(newState);
   });
 
-  it("should handle FETCH_BOOK_FAILURE", () => {
-    let action = actions.fetchBookFailure({
+  it("should handle BOOK_FAILURE", () => {
+    let action = actions.failure(ActionCreator.BOOK, {
       status: 500,
       response: "test error",
       url: "error url"
@@ -84,12 +85,12 @@ describe("book reducer", () => {
     expect(reducer(fetchingState, action)).to.deep.equal(newState);
   });
 
-  it("should handle LOAD_BOOK", () => {
+  it("should handle BOOK_LOAD", () => {
     let data = {
       id: "some id",
       title: "some title"
     };
-    let action = actions.loadBook(data, "some other url");
+    let action = actions.load<BookData>(ActionCreator.BOOK, data, "some other url");
     let newState = Object.assign({}, bookState, {
       url: "some other url",
       data: data,
@@ -99,8 +100,8 @@ describe("book reducer", () => {
     expect(reducer(bookState, action)).to.deep.equal(newState);
   });
 
-  it("should handle CLEAR_BOOK", () => {
-    let action = actions.clearBook();
+  it("should handle BOOK_CLEAR", () => {
+    let action = actions.clear(ActionCreator.BOOK);
     let newState = Object.assign({}, bookState, {
       url: null,
       data: null

--- a/packages/opds-web-client/src/reducers/__tests__/collection-test.ts
+++ b/packages/opds-web-client/src/reducers/__tests__/collection-test.ts
@@ -5,11 +5,12 @@ import * as history from "../history";
 
 import reducer from "../collection";
 import DataFetcher from "../../DataFetcher";
-import ActionsCreator from "../../actions";
+import ActionCreator from "../../actions";
 import { adapter } from "../../OPDSDataAdapter";
+import { CollectionData, SearchData } from "../../interfaces";
 
 let fetcher = new DataFetcher({ adapter });
-let actions = new ActionsCreator(fetcher);
+let actions = new ActionCreator(fetcher);
 
 describe("collection reducer", () => {
   let initState = {
@@ -97,8 +98,8 @@ describe("collection reducer", () => {
     expect(reducer(undefined, {})).to.deep.equal(initState);
   });
 
-  it("should handle FETCH_COLLECTION_REQUEST", () => {
-    let action = actions.fetchCollectionRequest("some other url");
+  it("should handle COLLECTION_REQUEST", () => {
+    let action = actions.request(ActionCreator.COLLECTION, "some other url");
     let newState = Object.assign({}, errorState, {
       isFetching: true,
       error: null
@@ -107,8 +108,8 @@ describe("collection reducer", () => {
     expect(reducer(errorState, action)).to.deep.equal(newState);
   });
 
-  it("should handle FETCH_COLLECTION_FAILURE", () => {
-    let action = actions.fetchCollectionFailure({
+  it("should handle COLLECTION_FAILURE", () => {
+    let action = actions.failure(ActionCreator.COLLECTION, {
       status: 500,
       response: "test error",
       url: "error url"
@@ -125,7 +126,7 @@ describe("collection reducer", () => {
     expect(reducer(fetchingState, action)).to.deep.equal(newState);
   });
 
-  it("should handle LOAD_COLLECTION", () => {
+  it("should handle COLLECTION_LOAD", () => {
     let data = {
       id: "some id",
       url: "some url",
@@ -134,7 +135,7 @@ describe("collection reducer", () => {
       books: [],
       navigationLinks: []
     };
-    let action = actions.loadCollection(data, "some other url");
+    let action = actions.load<CollectionData>(ActionCreator.COLLECTION, data, "some other url");
     let newState = Object.assign({}, currentState, {
       url: "some other url",
       data: data,
@@ -144,7 +145,7 @@ describe("collection reducer", () => {
     expect(reducer(currentState, action)).to.deep.equal(newState);
   });
 
-  it("should handle LOAD_COLLECTION after an error", () => {
+  it("should handle COLLECTION_LOAD after an error", () => {
     let data = {
       id: "some id",
       url: "some url",
@@ -153,7 +154,7 @@ describe("collection reducer", () => {
       books: [],
       navigationLinks: []
     };
-    let action = actions.loadCollection(data, "some url");
+    let action = actions.load<CollectionData>(ActionCreator.COLLECTION, data, "some url");
     let newState = Object.assign({}, errorState, {
       url: "some url",
       data: data,
@@ -164,8 +165,8 @@ describe("collection reducer", () => {
     expect(reducer(errorState, action)).to.deep.equal(newState);
   });
 
-  it("should handle CLEAR_COLLECTION", () => {
-    let action = actions.clearCollection();
+  it("should handle COLLECTION_CLEAR", () => {
+    let action = actions.clear(ActionCreator.COLLECTION);
     let newState = Object.assign({}, currentState, {
       url: null,
       data: null
@@ -174,8 +175,8 @@ describe("collection reducer", () => {
     expect(reducer(currentState, action)).to.deep.equal(newState);
   });
 
-  it("should handle FETCH_PAGE_REQUEST", () => {
-    let action = actions.fetchPageRequest("some other url");
+  it("should handle PAGE_REQUEST", () => {
+    let action = actions.request(ActionCreator.PAGE, "some other url");
     let newState = Object.assign({}, currentState, {
       pageUrl: "some other url",
       isFetchingPage: true
@@ -184,8 +185,8 @@ describe("collection reducer", () => {
     expect(reducer(currentState, action)).to.deep.equal(newState);
   });
 
-  it("should handle FETCH_PAGE_FAILURE", () => {
-    let action = actions.fetchPageFailure({
+  it("should handle PAGE_FAILURE", () => {
+    let action = actions.failure(ActionCreator.PAGE, {
       status: 500,
       response: "test error",
       url: "error url"
@@ -202,7 +203,7 @@ describe("collection reducer", () => {
     expect(reducer(fetchingPageState, action)).to.deep.equal(newState);
   });
 
-  it("should handle LOAD_PAGE", () => {
+  it("should handle PAGE_LOAD", () => {
     let data = {
       id: "some id",
       url: "test url",
@@ -219,7 +220,7 @@ describe("collection reducer", () => {
       navigationLinks: [],
       nextPageUrl: "next"
     };
-    let action = actions.loadPage(data);
+    let action = actions.load<CollectionData>(ActionCreator.PAGE, data);
     let newState = Object.assign({}, fetchingPageState, {
       data: Object.assign({}, fetchingPageState.data, {
         books: data.books,
@@ -231,13 +232,13 @@ describe("collection reducer", () => {
     expect(reducer(fetchingPageState, action)).to.deep.equal(newState);
   });
 
-  it("should handle LOAD_SEARCH_DESCRIPTION", () => {
+  it("should handle SEARCH_DESCRIPTION_LOAD", () => {
     let searchData = {
       description: "d",
       shortName: "s",
       template: (s) => s + " template"
     };
-    let action = actions.loadSearchDescription({ searchData });
+    let action = actions.load<SearchData>(ActionCreator.SEARCH_DESCRIPTION, { searchData });
 
     let newState = reducer(currentState, action);
     expect(newState.data.search).to.be.ok;

--- a/packages/opds-web-client/src/reducers/__tests__/history-test.ts
+++ b/packages/opds-web-client/src/reducers/__tests__/history-test.ts
@@ -2,12 +2,13 @@ import { expect } from "chai";
 
 import reducer, { shouldClear, shorten, addLink, addCollection } from "../history";
 import DataFetcher from "../../DataFetcher";
-import ActionsCreator from "../../actions";
+import ActionCreator from "../../actions";
 import { adapter } from "../../OPDSDataAdapter";
 import { CollectionState } from "../collection";
+import { CollectionData } from "../../interfaces";
 
 let fetcher = new DataFetcher({ adapter });
-let actions = new ActionsCreator(fetcher);
+let actions = new ActionCreator(fetcher);
 
 let rootLink = {
   id: null,
@@ -196,7 +197,7 @@ describe("history reducer", () => {
     history: []
   };
 
-  it("should handle LOAD_COLLECTION", () => {
+  it("should handle COLLECTION_LOAD", () => {
     let data = {
       id: "some id",
       url: "some url",
@@ -205,7 +206,7 @@ describe("history reducer", () => {
       books: [],
       navigationLinks: []
     };
-    let action = actions.loadCollection(data, "some other url");
+    let action = actions.load<CollectionData>(ActionCreator.COLLECTION, data, "some other url");
     let newHistory = [{
       id: "id",
       text: "title",
@@ -215,7 +216,7 @@ describe("history reducer", () => {
     expect(reducer(currentState, action)).to.deep.equal(newHistory);
   });
 
-  it("shouldn't change history on LOAD_COLLECTION with same id", () => {
+  it("shouldn't change history on COLLECTION_LOAD with same id", () => {
     let data = {
       id: "id",
       url: "some url",
@@ -224,11 +225,11 @@ describe("history reducer", () => {
       books: [],
       navigationLinks: []
     };
-    let action = actions.loadCollection(data, "some other url");
+    let action = actions.load<CollectionData>(ActionCreator.COLLECTION, data, "some other url");
     expect(reducer(currentState, action)).to.deep.equal(currentState.history);
   });
 
-  it("should clear history on LOAD_COLLECTION with the old catalog root", () => {
+  it("should clear history on COLLECTION_LOAD with the old catalog root", () => {
     let stateWithHistory = Object.assign({}, currentState, {
       history: [{
         id: "test id",
@@ -244,11 +245,11 @@ describe("history reducer", () => {
       books: [],
       navigationLinks: []
     };
-    let action = actions.loadCollection(data, "root url");
+    let action = actions.load<CollectionData>(ActionCreator.COLLECTION, data, "root url");
     expect(reducer(stateWithHistory, action)).to.deep.equal([]);
   });
 
-  it("should clear history on LOAD_COLLECTION with a new catalog", () => {
+  it("should clear history on COLLECTION_LOAD with a new catalog", () => {
     let stateWithHistory = Object.assign({}, currentState, {
       history: [{
         id: "test id",
@@ -268,7 +269,7 @@ describe("history reducer", () => {
       books: [],
       navigationLinks: []
     };
-    let action = actions.loadCollection(data, "some url");
+    let action = actions.load<CollectionData>(ActionCreator.COLLECTION, data, "some url");
     let newHistory = [{
       id: null,
       url: "new root url",
@@ -278,7 +279,7 @@ describe("history reducer", () => {
     expect(reducer(stateWithHistory, action)).to.deep.equal(newHistory);
   });
 
-  it("should remove history up to loaded url on LOAD_COLLECTION with url in history", () => {
+  it("should remove history up to loaded url on COLLECTION_LOAD with url in history", () => {
     let stateWithHistory = Object.assign({}, currentState, {
       history: [{
         id: "first id",
@@ -302,7 +303,7 @@ describe("history reducer", () => {
       books: [],
       navigationLinks: []
     };
-    let action = actions.loadCollection(data, "test url");
+    let action = actions.load<CollectionData>(ActionCreator.COLLECTION, data, "test url");
     let newHistory = [{
       id: "first id",
       url: "first url",
@@ -312,7 +313,7 @@ describe("history reducer", () => {
     expect(reducer(stateWithHistory, action)).to.deep.equal(newHistory);
   });
 
-  it("should handle LOAD_COLLECTION after an error", () => {
+  it("should handle COLLECTION_LOAD after an error", () => {
     let data = {
       id: "some id",
       url: "some url",
@@ -321,7 +322,7 @@ describe("history reducer", () => {
       books: [],
       navigationLinks: []
     };
-    let action = actions.loadCollection(data, "some url");
+    let action = actions.load<CollectionData>(ActionCreator.COLLECTION, data, "some url");
 
     expect(reducer(errorState, action)).to.deep.equal([]);
   });

--- a/packages/opds-web-client/src/reducers/__tests__/loans-test.ts
+++ b/packages/opds-web-client/src/reducers/__tests__/loans-test.ts
@@ -2,11 +2,12 @@ import { expect } from "chai";
 
 import reducer from "../loans";
 import DataFetcher from "../../DataFetcher";
-import ActionsCreator from "../../actions";
+import ActionCreator from "../../actions";
 import { adapter } from "../../OPDSDataAdapter";
+import { CollectionData, BookData } from "../../interfaces";
 
 let fetcher = new DataFetcher({ adapter });
-let actions = new ActionsCreator(fetcher);
+let actions = new ActionCreator(fetcher);
 let collectionData = {
   url: "collection url",
   title: "title",
@@ -16,11 +17,18 @@ let collectionData = {
   navigationLinks: [],
   shelfUrl: "loans url"
 };
-let loansData = [{
-  id: "book id",
-  url: "book url",
-  title: "book title"
-}];
+let loansData = {
+  url: "collection url",
+  title: "title",
+  id: "id",
+  books: [{
+    id: "book id",
+    url: "book url",
+    title: "book title"
+  }],
+  lanes: [],
+  navigationLinks: []
+};
 
 describe("loans reducer", () => {
   let initState = {
@@ -32,33 +40,33 @@ describe("loans reducer", () => {
     expect(reducer(undefined, {})).to.deep.equal(initState);
   });
 
-  it("handles LOAD_COLLECTION", () => {
-    let action = actions.loadCollection(collectionData);
+  it("handles COLLECTION_LOAD", () => {
+    let action = actions.load<CollectionData>(ActionCreator.COLLECTION, collectionData);
     let newState = Object.assign({}, initState, {
       url: "loans url"
     });
     expect(reducer(initState, action)).to.deep.equal(newState);
   });
 
-  it("handles LOAD_COLLECTION for loans feed", () => {
+  it("handles COLLECTION_LOAD for loans feed", () => {
     let oldState = Object.assign({}, initState, {
       url: "loans url"
     });
     let loansCollectionData = Object.assign({}, collectionData, { books: loansData });
-    let action = actions.loadCollection(loansCollectionData, "loans url");
+    let action = actions.load<CollectionData>(ActionCreator.COLLECTION, loansCollectionData, "loans url");
     let newState = Object.assign({}, oldState, {
       books: loansData
     });
     expect(reducer(oldState, action)).to.deep.equal(newState);
   });
 
-  it("handles LOAD_LOANS", () => {
+  it("handles LOANS_LOAD", () => {
     let oldState = Object.assign({}, initState, {
       url: "loans url"
     });
-    let action = actions.loadLoans(loansData);
+    let action = actions.load<CollectionData>(ActionCreator.LOANS, loansData);
     let newState = Object.assign({}, oldState, {
-      books: loansData
+      books: loansData.books
     });
 
     expect(reducer(oldState, action)).to.deep.equal(newState);
@@ -75,7 +83,7 @@ describe("loans reducer", () => {
     expect(reducer(oldState, action)).to.deep.equal(newState);
   });
 
-  it("clears books on LOAD_UPDATE_BOOK_DATA", () => {
+  it("clears books on UPDATE_BOOK_LOAD", () => {
     let oldState = Object.assign({}, initState, {
         books: loansData
     });
@@ -84,7 +92,7 @@ describe("loans reducer", () => {
       url: "book url",
       title: "new book title"
     };
-    let action = actions.loadUpdateBookData(newBookData);
+    let action = actions.load<BookData>(ActionCreator.UPDATE_BOOK, newBookData);
     let newState = Object.assign({}, oldState, {
       books: []
     });

--- a/packages/opds-web-client/src/reducers/auth.ts
+++ b/packages/opds-web-client/src/reducers/auth.ts
@@ -1,4 +1,5 @@
 import { AuthCallback, AuthData } from "../interfaces";
+import ActionCreator from "../actions";
 
 export interface AuthState extends AuthData {};
 
@@ -15,7 +16,7 @@ const initialState: AuthState = {
 
 export default (state: AuthState = initialState, action): AuthState => {
   switch (action.type) {
-    case "SHOW_AUTH_FORM":
+    case ActionCreator.SHOW_AUTH_FORM:
       return Object.assign({}, state, {
         showForm: true,
         callback: action.callback,
@@ -26,18 +27,18 @@ export default (state: AuthState = initialState, action): AuthState => {
         providers: action.providers
       });
 
-    case "HIDE_AUTH_FORM":
+    case ActionCreator.HIDE_AUTH_FORM:
       return Object.assign({}, state, {
         showForm: false,
         error: null
       });
 
-    case "SAVE_AUTH_CREDENTIALS":
+    case ActionCreator.SAVE_AUTH_CREDENTIALS:
       return Object.assign({}, state, {
         credentials: action.credentials
       });
 
-    case "CLEAR_AUTH_CREDENTIALS":
+    case ActionCreator.CLEAR_AUTH_CREDENTIALS:
       return Object.assign({}, state, {
         credentials: null
       });

--- a/packages/opds-web-client/src/reducers/book.ts
+++ b/packages/opds-web-client/src/reducers/book.ts
@@ -1,4 +1,5 @@
 import { BookData, FetchErrorData } from "../interfaces";
+import ActionCreator from "../actions";
 
 export interface BookState {
   url: string;
@@ -16,57 +17,57 @@ const initialState: BookState = {
 
 const book = (state: BookState = initialState, action): BookState => {
   switch (action.type) {
-    case "FETCH_BOOK_REQUEST":
+    case ActionCreator.FETCH_BOOK_REQUEST:
       return Object.assign({}, state, {
         isFetching: true,
         error: null
       });
 
-    case "FETCH_BOOK_FAILURE":
+    case ActionCreator.FETCH_BOOK_FAILURE:
       return Object.assign({}, state, {
         isFetching: false,
         error: action.error
       });
 
-    case "LOAD_BOOK":
+    case ActionCreator.LOAD_BOOK:
       return Object.assign({}, state, {
         data: action.data,
         url: action.url ? action.url : state.url,
         isFetching: false
       });
 
-    case "CLEAR_BOOK":
+    case ActionCreator.CLEAR_BOOK:
       return Object.assign({}, state, {
         data: null,
         url: null,
         error: null
       });
 
-    case "CLOSE_ERROR":
+    case ActionCreator.CLOSE_ERROR:
       return Object.assign({}, state, {
         error: null
       });
 
-    case "FULFILL_BOOK_REQUEST":
-    case "UPDATE_BOOK_REQUEST":
+    case ActionCreator.FULFILL_BOOK_REQUEST:
+    case ActionCreator.UPDATE_BOOK_REQUEST:
       return Object.assign({}, state, {
         isFetching: true
       });
 
-    case "FULFILL_BOOK_SUCCESS":
-    case "UPDATE_BOOK_SUCCESS":
+    case ActionCreator.FULFILL_BOOK_SUCCESS:
+    case ActionCreator.UPDATE_BOOK_SUCCESS:
       return Object.assign({}, state, {
         isFetching: false
       });
 
-    case "FULFILL_BOOK_FAILURE":
-    case "UPDATE_BOOK_FAILURE":
+    case ActionCreator.FULFILL_BOOK_FAILURE:
+    case ActionCreator.UPDATE_BOOK_FAILURE:
       return Object.assign({}, state, {
         isFetching: false,
         error: action.error
       });
 
-    case "LOAD_UPDATE_BOOK_DATA":
+    case ActionCreator.LOAD_UPDATE_BOOK_DATA:
       return Object.assign({}, state, {
         data: Object.assign({}, state.data, action.data)
       });

--- a/packages/opds-web-client/src/reducers/book.ts
+++ b/packages/opds-web-client/src/reducers/book.ts
@@ -17,26 +17,26 @@ const initialState: BookState = {
 
 const book = (state: BookState = initialState, action): BookState => {
   switch (action.type) {
-    case ActionCreator.FETCH_BOOK_REQUEST:
+    case ActionCreator.BOOK_REQUEST:
       return Object.assign({}, state, {
         isFetching: true,
         error: null
       });
 
-    case ActionCreator.FETCH_BOOK_FAILURE:
+    case ActionCreator.BOOK_FAILURE:
       return Object.assign({}, state, {
         isFetching: false,
         error: action.error
       });
 
-    case ActionCreator.LOAD_BOOK:
+    case ActionCreator.BOOK_LOAD:
       return Object.assign({}, state, {
         data: action.data,
         url: action.url ? action.url : state.url,
         isFetching: false
       });
 
-    case ActionCreator.CLEAR_BOOK:
+    case ActionCreator.BOOK_CLEAR:
       return Object.assign({}, state, {
         data: null,
         url: null,
@@ -67,7 +67,7 @@ const book = (state: BookState = initialState, action): BookState => {
         error: action.error
       });
 
-    case ActionCreator.LOAD_UPDATE_BOOK_DATA:
+    case ActionCreator.UPDATE_BOOK_LOAD:
       return Object.assign({}, state, {
         data: Object.assign({}, state.data, action.data)
       });

--- a/packages/opds-web-client/src/reducers/collection.ts
+++ b/packages/opds-web-client/src/reducers/collection.ts
@@ -1,5 +1,6 @@
 import { CollectionData, LinkData, FetchErrorData } from "../interfaces";
 import history from "./history";
+import ActionCreator from "../actions";
 
 export interface CollectionState {
   url: string;
@@ -21,19 +22,19 @@ const initialState: CollectionState = {
 
 const collection = (state = initialState, action) => {
   switch (action.type) {
-    case "FETCH_COLLECTION_REQUEST":
+    case ActionCreator.FETCH_COLLECTION_REQUEST:
       return Object.assign({}, state, {
         isFetching: true,
         error: null
       });
 
-    case "FETCH_COLLECTION_FAILURE":
+    case ActionCreator.FETCH_COLLECTION_FAILURE:
       return Object.assign({}, state, {
         isFetching: false,
         error: action.error
       });
 
-    case "LOAD_COLLECTION":
+    case ActionCreator.LOAD_COLLECTION:
       return Object.assign({}, state, {
         data: action.data,
         url: action.url ? action.url : state.url,
@@ -42,7 +43,7 @@ const collection = (state = initialState, action) => {
         history: history(state, action)
       });
 
-    case "CLEAR_COLLECTION":
+    case ActionCreator.CLEAR_COLLECTION:
       return Object.assign({}, state, {
         data: null,
         url: null,
@@ -50,20 +51,20 @@ const collection = (state = initialState, action) => {
         history: state.history.slice(0, -1)
       });
 
-    case "FETCH_PAGE_REQUEST":
+    case ActionCreator.FETCH_PAGE_REQUEST:
       return Object.assign({}, state, {
         pageUrl: action.url,
         isFetchingPage: true,
         error: null
       });
 
-    case "FETCH_PAGE_FAILURE":
+    case ActionCreator.FETCH_PAGE_FAILURE:
       return Object.assign({}, state, {
         isFetchingPage: false,
         error: action.error
       });
 
-    case "LOAD_PAGE":
+    case ActionCreator.LOAD_PAGE:
       return Object.assign({}, state, {
         data: Object.assign({}, state.data, {
           books: Object.assign([], state.data.books).concat(action.data.books),
@@ -72,14 +73,14 @@ const collection = (state = initialState, action) => {
         isFetchingPage: false
       });
 
-    case "LOAD_SEARCH_DESCRIPTION":
+    case ActionCreator.LOAD_SEARCH_DESCRIPTION:
       return Object.assign({}, state, {
         data: Object.assign({}, state.data, {
           search: action.data
         })
       });
 
-    case "CLOSE_ERROR":
+    case ActionCreator.CLOSE_ERROR:
       return Object.assign({}, state, {
         error: null
       });

--- a/packages/opds-web-client/src/reducers/collection.ts
+++ b/packages/opds-web-client/src/reducers/collection.ts
@@ -22,19 +22,19 @@ const initialState: CollectionState = {
 
 const collection = (state = initialState, action) => {
   switch (action.type) {
-    case ActionCreator.FETCH_COLLECTION_REQUEST:
+    case ActionCreator.COLLECTION_REQUEST:
       return Object.assign({}, state, {
         isFetching: true,
         error: null
       });
 
-    case ActionCreator.FETCH_COLLECTION_FAILURE:
+    case ActionCreator.COLLECTION_FAILURE:
       return Object.assign({}, state, {
         isFetching: false,
         error: action.error
       });
 
-    case ActionCreator.LOAD_COLLECTION:
+    case ActionCreator.COLLECTION_LOAD:
       return Object.assign({}, state, {
         data: action.data,
         url: action.url ? action.url : state.url,
@@ -43,7 +43,7 @@ const collection = (state = initialState, action) => {
         history: history(state, action)
       });
 
-    case ActionCreator.CLEAR_COLLECTION:
+    case ActionCreator.COLLECTION_CLEAR:
       return Object.assign({}, state, {
         data: null,
         url: null,
@@ -51,20 +51,20 @@ const collection = (state = initialState, action) => {
         history: state.history.slice(0, -1)
       });
 
-    case ActionCreator.FETCH_PAGE_REQUEST:
+    case ActionCreator.PAGE_REQUEST:
       return Object.assign({}, state, {
         pageUrl: action.url,
         isFetchingPage: true,
         error: null
       });
 
-    case ActionCreator.FETCH_PAGE_FAILURE:
+    case ActionCreator.PAGE_FAILURE:
       return Object.assign({}, state, {
         isFetchingPage: false,
         error: action.error
       });
 
-    case ActionCreator.LOAD_PAGE:
+    case ActionCreator.PAGE_LOAD:
       return Object.assign({}, state, {
         data: Object.assign({}, state.data, {
           books: Object.assign([], state.data.books).concat(action.data.books),
@@ -73,7 +73,7 @@ const collection = (state = initialState, action) => {
         isFetchingPage: false
       });
 
-    case ActionCreator.LOAD_SEARCH_DESCRIPTION:
+    case ActionCreator.SEARCH_DESCRIPTION_LOAD:
       return Object.assign({}, state, {
         data: Object.assign({}, state.data, {
           search: action.data

--- a/packages/opds-web-client/src/reducers/history.ts
+++ b/packages/opds-web-client/src/reducers/history.ts
@@ -1,5 +1,5 @@
 import { CollectionState } from "./collection";
-import { LoadCollectionAction } from "../actions";
+import { LoadAction } from "../actions";
 import { CollectionData, LinkData } from "../interfaces";
 
 function newCollectionIsOldCollection(newCollection: CollectionData, oldCollection: CollectionData): boolean {
@@ -64,7 +64,7 @@ export function onlyRoot(newCollection:  CollectionData) {
   return addLink([], newCollection.catalogRootLink);
 }
 
-export default (state: CollectionState, action: LoadCollectionAction) => {
+export default (state: CollectionState, action: LoadAction<CollectionData>) => {
   let newHistory = state.history.slice(0);
   let newCollection = Object.freeze(action.data);
   let oldCollection = Object.freeze(state.data);

--- a/packages/opds-web-client/src/reducers/loans.ts
+++ b/packages/opds-web-client/src/reducers/loans.ts
@@ -13,7 +13,7 @@ const initialState: LoansState = {
 
 export default (state: LoansState = initialState, action): LoansState => {
   switch (action.type) {
-    case ActionCreator.LOAD_COLLECTION:
+    case ActionCreator.COLLECTION_LOAD:
       let loansUrl = action.data.shelfUrl || state.url;
       let isLoans = action.url === loansUrl;
 
@@ -22,9 +22,9 @@ export default (state: LoansState = initialState, action): LoansState => {
         books: isLoans ? action.data.books : state.books
       });
 
-    case ActionCreator.LOAD_LOANS:
+    case ActionCreator.LOANS_LOAD:
       return Object.assign({}, state, {
-        books: action.books
+        books: action.data.books
       });
 
     case ActionCreator.CLEAR_AUTH_CREDENTIALS:
@@ -34,7 +34,7 @@ export default (state: LoansState = initialState, action): LoansState => {
         books: []
       });
 
-    case ActionCreator.LOAD_UPDATE_BOOK_DATA:
+    case ActionCreator.UPDATE_BOOK_LOAD:
       // A book has been updated, so the loans feed is now outdated.
       // If we remove the loans, the components showing the book that
       // was updated can use the data from the book update request 

--- a/packages/opds-web-client/src/reducers/loans.ts
+++ b/packages/opds-web-client/src/reducers/loans.ts
@@ -1,4 +1,5 @@
 import { BookData } from "../interfaces";
+import ActionCreator from "../actions";
 
 export interface LoansState {
   url: string;
@@ -12,7 +13,7 @@ const initialState: LoansState = {
 
 export default (state: LoansState = initialState, action): LoansState => {
   switch (action.type) {
-    case "LOAD_COLLECTION":
+    case ActionCreator.LOAD_COLLECTION:
       let loansUrl = action.data.shelfUrl || state.url;
       let isLoans = action.url === loansUrl;
 
@@ -21,19 +22,19 @@ export default (state: LoansState = initialState, action): LoansState => {
         books: isLoans ? action.data.books : state.books
       });
 
-    case "LOAD_LOANS":
+    case ActionCreator.LOAD_LOANS:
       return Object.assign({}, state, {
         books: action.books
       });
 
-    case "CLEAR_AUTH_CREDENTIALS":
+    case ActionCreator.CLEAR_AUTH_CREDENTIALS:
       // Clear auth credentials should remove the authenticated
       // user's loans as well.
       return Object.assign({}, state, {
         books: []
       });
 
-    case "LOAD_UPDATE_BOOK_DATA":
+    case ActionCreator.LOAD_UPDATE_BOOK_DATA:
       // A book has been updated, so the loans feed is now outdated.
       // If we remove the loans, the components showing the book that
       // was updated can use the data from the book update request 


### PR DESCRIPTION
This starts #190.

I set up a few general fetch methods that can be used in other actions so there's less duplicated code. It doesn't help much in this repo, though I'll be able to get rid of many of the constants when I refactor the reducers, and I can also get rid of more of the tests at some point. However, it makes a huge difference in circulation-web - using this refactoring I was able to get rid of over 1000 lines there.