### PR TITLE
Added an option to specify an epub reader URL template, and incorporated EDRLab's webpub streamer and NYPL's webpub navigator into the demo server.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ For an example of OPDS Web Client in use as a standalone app, see the [demo serv
 - `computeBreadcrumbs`: optional function for customizing breadcrumbs. It defaults to `defaultComputeBreadcrumbs` in the [Breadcrumbs](packages/opds-web-client/src/components/Breadcrumbs.tsx) module, and `hierarchyComputeBreacrumbs` is also available. It should return an array of link objects, each with `url` and `text` properties. Its accepts two arguments:
   - `collection`: object representing the current collection data (see `CollectionData` in the [interfaces file](packages/opds-web-client/src/interfaces.ts))
   - `history`: an array of link objects (each with `url` and `text` properties) that is appended every time the user navigates to a new collection
+- `epubReaderUrlTemplate(epubUrl: string) => string`: optional function that returns a URL where you can read an EPUB file.
 
 ## React Component
 The application is also available as a reusable React component:
@@ -49,6 +50,7 @@ For an example of the application in use as a React component, see [NYPL-Simplif
 - `Header`: optional custom React component class to render in place of the client's default header. This `Header` will receive three props, `collectionTitle`, `bookTitle`, and a `CatalogLink` which should be used for links to collections or books that the client should load, and one child, a `Search` component that will only be present when the loaded collection links to an Open Search Description document. Default: `undefined`
 - `BookDetailsContainer`: optional custom React component class to render in place of the client's default `BookDetails` component. This `BookDetailsContainer` will receive three props: the current `collectionUrl` and `bookUrl`, and `refreshCatalog`, a function that can be called to refresh the collection and/or book. `BookDetailsContainer` will also receive the default rendered `BookDetails` component as a child. Default: `undefined`
 - `computeBreadcrumbs`: same as in "Standalone Config Options" above
+- `epubReaderUrlTemplate`: same as in "Standalone Config Options" above
 
 ### React Component Context
 

--- a/packages/opds-web-client/src/components/BookDetails.tsx
+++ b/packages/opds-web-client/src/components/BookDetails.tsx
@@ -13,6 +13,7 @@ export interface BookDetailsProps extends BookProps {
   fulfillBook: (url: string) => Promise<Blob>;
   indirectFulfillBook: (url: string, type: string) => Promise<string>;
   isSignedIn?: boolean;
+  epubReaderUrlTemplate?: (epubUrl: string) => string;
 }
 
 export default class BookDetails<P extends BookDetailsProps> extends React.Component<P, void> {
@@ -119,6 +120,22 @@ export default class BookDetails<P extends BookDetailsProps> extends React.Compo
     let links = [];
 
     if (this.isOpenAccess()) {
+      if (this.props.epubReaderUrlTemplate) {
+        for (const link of this.props.book.openAccessLinks) {
+          if (link.type === "application/epub+zip") {
+            links.push(
+              <span>
+                <a
+                  className="btn btn-default read-button"
+                  href={this.props.epubReaderUrlTemplate(link.url)}
+                  >Read
+                </a>
+              </span>
+            );
+          }
+        }
+      }
+
       links.push(
         this.props.book.openAccessLinks.map(link => {
           return (

--- a/packages/opds-web-client/src/components/BookDetails.tsx
+++ b/packages/opds-web-client/src/components/BookDetails.tsx
@@ -128,6 +128,7 @@ export default class BookDetails<P extends BookDetailsProps> extends React.Compo
                 <a
                   className="btn btn-default read-button"
                   href={this.props.epubReaderUrlTemplate(link.url)}
+                  target="_blank"
                   >Read
                 </a>
               </span>

--- a/packages/opds-web-client/src/components/OPDSCatalog.tsx
+++ b/packages/opds-web-client/src/components/OPDSCatalog.tsx
@@ -17,6 +17,7 @@ export interface OPDSCatalogProps {
   pageTitleTemplate: (collectionTitle: string, bookTitle: string) => string;
   proxyUrl?: string;
   initialState?: State;
+  epubReaderUrlTemplate?: (epubUrl: string) => string;
 }
 
 export default class OPDSCatalog extends React.Component<OPDSCatalogProps, void> {

--- a/packages/opds-web-client/src/components/Root.tsx
+++ b/packages/opds-web-client/src/components/Root.tsx
@@ -60,6 +60,7 @@ export interface RootProps extends StateProps {
   retryCollectionAndBook?: () => Promise<any>;
   pageTitleTemplate?: (collectionTitle: string, bookTitle: string) => string;
   headerTitle?: string;
+  epubReaderUrlTemplate?: (epubUrl: string) => string;
   fetchPage?: (url: string) => Promise<CollectionData>;
   Header?: new() => __React.Component<HeaderProps, any>;
   Footer?: new() => __React.Component<FooterProps, any>;
@@ -225,6 +226,7 @@ export class Root extends React.Component<RootProps, RootState> {
                         fulfillBook={this.props.fulfillBook}
                         indirectFulfillBook={this.props.indirectFulfillBook}
                         isSignedIn={this.props.isSignedIn}
+                        epubReaderUrlTemplate={this.props.epubReaderUrlTemplate}
                         />
                     </BookDetailsContainer> :
                     <div className="without-container">
@@ -234,6 +236,7 @@ export class Root extends React.Component<RootProps, RootState> {
                         fulfillBook={this.props.fulfillBook}
                         indirectFulfillBook={this.props.indirectFulfillBook}
                         isSignedIn={this.props.isSignedIn}
+                        epubReaderUrlTemplate={this.props.epubReaderUrlTemplate}
                         />
                     </div>
                   )

--- a/packages/opds-web-client/src/components/__tests__/BookDetails-test.tsx
+++ b/packages/opds-web-client/src/components/__tests__/BookDetails-test.tsx
@@ -18,7 +18,7 @@ let book = {
   contributors: ["contributor 1"],
   summary: "&lt;b&gt;Sam and Remi Fargo race for treasure&#8212;and survival&#8212;in this lightning-paced new adventure from #1&lt;i&gt; New York Times&lt;/i&gt; bestselling author Clive Cussler.&lt;/b&gt;&lt;br /&gt;&lt;br /&gt;Husband-and-wife team Sam and Remi Fargo are in Mexico when they come upon a remarkable discovery&#8212;the mummified remainsof a man clutching an ancient sealed pot. Within the pot is a Mayan book larger than any known before.&lt;br /&gt;&lt;br /&gt;The book contains astonishing information about the Mayans, their cities, and about mankind itself. The secrets are so powerful that some people would do anything to possess them&#8212;as the Fargos are about to find out. Many men and women are going to die for that book.",
   imageUrl: "https://dlotdqc6pnwqb.cloudfront.net/3M/crrmnr9/cover.jpg",
-  openAccessLinks: [{ url: "secrets.epub", type: "application/epub+zip" }],
+  openAccessLinks: [{ url: "secrets.epub", type: "application/epub+zip" }, { url: "secrets.mobi", type: "application/x-mobipocket-ebook" }],
   borrowUrl: "borrow url",
   publisher: "Penguin Publishing Group",
   published: "February 29, 2016",
@@ -39,6 +39,7 @@ describe("BookDetails", () => {
         updateBook={stub()}
         fulfillBook={stub()}
         indirectFulfillBook={stub()}
+        epubReaderUrlTemplate={stub().returns("test reader url")}
         />
     );
   });
@@ -131,11 +132,25 @@ describe("BookDetails", () => {
     expect(summary.props().lang).to.equal("de");
   });
 
-  it("shows download button for open access url", () => {
-    let button = wrapper.find(DownloadButton);
-    expect(button.props().url).to.equal("secrets.epub");
-    expect(button.props().mimeType).to.equal("application/epub+zip");
-    expect(button.props().isPlainLink).to.equal(true);
+  it("shows download button for open access urls", () => {
+    let buttons = wrapper.find(DownloadButton);
+    expect(buttons.length).to.equal(2);
+    let epubButton = buttons.at(0);
+    let mobiButton = buttons.at(1);
+
+    expect(epubButton.props().url).to.equal("secrets.epub");
+    expect(epubButton.props().mimeType).to.equal("application/epub+zip");
+    expect(epubButton.props().isPlainLink).to.equal(true);
+
+    expect(mobiButton.props().url).to.equal("secrets.mobi");
+    expect(mobiButton.props().mimeType).to.equal("application/x-mobipocket-ebook");
+    expect(mobiButton.props().isPlainLink).to.equal(true);
+  });
+
+  it("shows read button for open access epub urls", () => {
+    let buttons = wrapper.find(".read-button");
+    expect(buttons.length).to.equal(1);
+    expect(buttons.props().href).to.equal("test reader url");
   });
 
   it("shows borrow/hold button", () => {

--- a/packages/opds-web-client/src/components/__tests__/OPDSCatalog-test.tsx
+++ b/packages/opds-web-client/src/components/__tests__/OPDSCatalog-test.tsx
@@ -23,7 +23,8 @@ describe("OPDSCatalog", () => {
       title: "book title",
       url: "book url"
     },
-    pageTitleTemplate: (c, b) => "test title"
+    pageTitleTemplate: (c, b) => "test title",
+    epubReaderUrlTemplate: (a) => "test reader url"
   };
 
   it("creates a store for Root if not given one", () => {

--- a/packages/opds-web-client/src/components/__tests__/Root-test.tsx
+++ b/packages/opds-web-client/src/components/__tests__/Root-test.tsx
@@ -318,6 +318,7 @@ describe("Root", () => {
     let updateBook = stub();
     let fulfillBook = stub();
     let indirectFulfillBook = stub();
+    let epubReaderUrlTemplate = stub();
     let wrapper = shallow(
       <Root
         bookData={bookData}
@@ -326,6 +327,7 @@ describe("Root", () => {
         fulfillBook={fulfillBook}
         indirectFulfillBook={indirectFulfillBook}
         isSignedIn={true}
+        epubReaderUrlTemplate={epubReaderUrlTemplate}
         />
     );
 
@@ -338,6 +340,7 @@ describe("Root", () => {
     expect(book.props().fulfillBook).to.equal(fulfillBook);
     expect(book.props().indirectFulfillBook).to.equal(indirectFulfillBook);
     expect(book.props().isSignedIn).to.equal(true);
+    expect(book.props().epubReaderUrlTemplate).to.equal(epubReaderUrlTemplate);
   });
 
   it("shows breadcrumbs", () => {
@@ -395,6 +398,7 @@ describe("Root", () => {
       let refresh = stub();
       let updateBook = stub();
       let fulfillBook = stub();
+      let epubReaderUrlTemplate = stub();
       let wrapper = shallow(
         <Root
           bookData={bookData}
@@ -405,6 +409,7 @@ describe("Root", () => {
           BookDetailsContainer={Container}
           updateBook={updateBook}
           fulfillBook={fulfillBook}
+          epubReaderUrlTemplate={epubReaderUrlTemplate}
           />
       );
 
@@ -416,6 +421,7 @@ describe("Root", () => {
       expect(container.props().book).to.equal(bookData);
       expect(child.type()).to.equal(BookDetails);
       expect(child.props().book).to.equal(bookData);
+      expect(child.props().epubReaderUrlTemplate).to.equal(epubReaderUrlTemplate);
     });
 
     it("does not render BookDetailsContainer if bookUrl and bookData.url are missing", () => {

--- a/packages/server/index.js
+++ b/packages/server/index.js
@@ -6,13 +6,50 @@ var port = process.env.PORT || 3000;
 var multer  = require('multer');
 var form = multer();
 
+var serverManifestJson = require("r2-streamer-js/dist/src/server-manifestjson").serverManifestJson;
+var serverMediaOverlays = require("r2-streamer-js/dist/src/server-mediaoverlays").serverMediaOverlays;
+var serverPub = require("r2-streamer-js/dist/src/server-pub").serverPub;
+var serverAssets = require("r2-streamer-js/dist/src/server-assets").serverAssets;
+var Server = require("r2-streamer-js/dist/src/server").Server
+
 app.use(express.static(__dirname + "/../opds-web-client/dist"));
+app.use(express.static(__dirname + "/node_modules/nypl-simplified-webpub-viewer/dist"));
+app.use(express.static(__dirname + "/node_modules/whatwg-fetch"));
+app.use(express.static(__dirname + "/node_modules/promise-polyfill"));
+app.use(express.static(__dirname + "/node_modules/requirejs"));
+app.use(express.static(__dirname + "/node_modules/url-polyfill"));
 app.set('views', __dirname + "/views");
 app.set('view engine', 'ejs');
 
 app.listen(port, function() {
   console.log("Server listening on port " + port);
 });
+
+class RemoteEpubServer {
+  constructor() {
+    this.publications = [];
+    this.pathPublicationMap = {};
+    var router = serverPub(this, app);
+    serverManifestJson(this, router);
+    serverAssets(this, router);
+    serverMediaOverlays(this, router);
+  }
+
+  addPublications(pubs) {
+    Server.prototype.addPublications.call(this, pubs);
+  }
+  isPublicationCached(filePath) {
+    Server.prototype.isPublicationCached.call(this, filePath);
+  }
+  cachedPublication(filePath) {
+    Server.prototype.cachedPublication.call(this, filePath);
+  }
+  cachePublication(filePath, pub) {
+    Server.prototype.cachePublication.call(this, filePath, pub);
+  }
+}
+
+var streamer = new RemoteEpubServer();
 
 app.post("/proxy", form.array(), function(req, res, next) {
   res.setHeader("Access-Control-Allow-Origin", "*");
@@ -39,6 +76,10 @@ app.options("/proxy", function(req, res, next) {
   res.setHeader("Access-Control-Allow-Methods", req.headers["access-control-request-method"]);
   res.setHeader("Access-Control-Allow-Headers", req.headers["access-control-request-headers"]);
   res.status(200).end();
+});
+
+app.get("/reader", function (req, res, next) {
+  res.render("reader.html.ejs");
 });
 
 app.get("/*", function(req, res, next) {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -17,6 +17,9 @@
     "ejs": "^2.4.1",
     "express": "^4.13.4",
     "multer": "^1.1.0",
-    "request": "^2.69.0"
+    "r2-streamer-js": "0.0.1-alpha13",
+    "request": "^2.69.0",
+    "requirejs": "^2.3.2",
+    "nypl-simplified-webpub-viewer": "0.0.3"
   }
 }

--- a/packages/server/views/index.html.ejs
+++ b/packages/server/views/index.html.ejs
@@ -34,7 +34,10 @@
           path += bookUrl ? `book/${encodeURIComponent(bookUrl)}/` : "";
           return path;
         },
-        pathPattern: "/(collection/:collectionUrl/)(book/:bookUrl/)"
+        pathPattern: "/(collection/:collectionUrl/)(book/:bookUrl/)",
+        epubReaderUrlTemplate: function (epubUrl) {
+          return "/reader?url=" + encodeURIComponent(new URL("/pub/" + btoa(epubUrl) + "/manifest.json", window.location.href).href);
+        }
       }, "opds-web-client");
     </script>
   </body>

--- a/packages/server/views/reader.html.ejs
+++ b/packages/server/views/reader.html.ejs
@@ -1,0 +1,84 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>Webpub Reader</title>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <link rel="apple-touch-icon" href="cover.jpg" type="image/jpeg">
+    <link rel="stylesheet" href="styles/css/main.css">
+    <script src="require.js"></script>
+    <script src="fetch.js"></script>
+    <script src="url.js"></script>
+    <script src="promise.js"></script>
+    <script src="webpub-viewer.js"></script>
+  </head>
+  <body>
+  <div id="viewer">
+  </div>
+  <script>
+    var getURLQueryParams = function() {
+      var params = {};
+      var query = window.location.search;
+      if (query && query.length) {
+        query = query.substring(1);
+        var keyParams = query.split('&');
+        for (var x = 0; x < keyParams.length; x++) {
+          var keyVal = keyParams[x].split('=');
+          if (keyVal.length > 1) {
+            params[keyVal[0]] = decodeURIComponent(keyVal[1]);
+          }
+        }
+      }
+      return params;
+    };
+
+    require(["LocalStorageStore", "ServiceWorkerCacher", "IFrameNavigator", "ColumnsPaginatedBookView", "ScrollingBookView", "LocalAnnotator", "BookSettings"],
+            function (LocalStorageStore, ServiceWorkerCacher, IFrameNavigator, ColumnsPaginatedBookView, ScrollingBookView, LocalAnnotator, BookSettings) {
+      var element = document.getElementById("viewer");
+      var urlParams = getURLQueryParams();
+      var webpubManifestUrl = new URL(urlParams['url']);
+      var store = new LocalStorageStore.default({ prefix: webpubManifestUrl.href });
+      var cacher = new ServiceWorkerCacher.default({
+        store: store,
+        manifestUrl: webpubManifestUrl,
+        serviceWorkerUrl: new URL("sw.js", window.location.href),
+        staticFileUrls: [
+          new URL(window.location.href),
+          new URL("index.html", window.location.href),
+          new URL("styles/css/main.css", window.location.href),
+          new URL("require.js", window.location.href),
+          new URL("fetch.js", window.location.href),
+          new URL("url.js", window.location.href),
+          new URL("promise.js", window.location.href),
+          new URL("webpub-viewer.js", window.location.href)
+        ]
+      });
+      var paginator = new ColumnsPaginatedBookView.default();
+      var scroller = new ScrollingBookView.default();
+      var annotator = new LocalAnnotator.default({ store: store });
+      var settingsStore = new LocalStorageStore.default({ prefix: "opds-web-client" });
+      var fontSizes = [ 12, 14, 16, 18, 20, 22, 24, 26, 28, 30, 32 ];
+      var defaultFontSize = 20;
+      BookSettings.default.create({
+        store: settingsStore,
+        bookViews: [paginator, scroller],
+        fontSizesInPixels: fontSizes,
+        defaultFontSizeInPixels: defaultFontSize
+      }).then(function (settings) {
+        IFrameNavigator.default.create({
+          element: element,
+          manifestUrl: webpubManifestUrl,
+          store: store,
+          cacher: cacher,
+          settings: settings,
+          annotator: annotator,
+          paginator: paginator,
+          scroller: scroller
+        });
+      });
+    });
+  </script>
+  </body>
+</html>


### PR DESCRIPTION
On the demo server, any books that have an open access EPUB URL will have a "Read" button that opens up the reader with a manifest from the streamer.