### PR TITLE
New auth document format

### DIFF
--- a/packages/opds-web-client/package.json
+++ b/packages/opds-web-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opds-web-client",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "description": "OPDS web client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/packages/opds-web-client/src/__tests__/authMiddleware-test.ts
+++ b/packages/opds-web-client/src/__tests__/authMiddleware-test.ts
@@ -132,7 +132,7 @@ describe("authMiddleware", () => {
 
   it("shows auth form with provider info from failed request if there were no existing credentials", (done) => {
     store.getState.returns({ auth: {}, collection: {}, book: {} });
-    let authentication = [{ type: "test", description: "a provider" }];
+    let authentication = [{ type: "test", id: "a provider" }];
     let error = {
       status: 401,
       response: JSON.stringify({ title: "Library", authentication })
@@ -141,7 +141,7 @@ describe("authMiddleware", () => {
     authMiddleware(store)(next)(() => {}).then(() => {
       expect(showAuthFormStub.callCount).to.equal(1);
       expect(showAuthFormStub.args[0][2]).to.deep.equal([{
-        name: "a provider",
+        id: "a provider",
         plugin: plugin,
         method: authentication[0]
       }]);
@@ -153,7 +153,7 @@ describe("authMiddleware", () => {
   it("shows auth form with provider info from store if existing credentials failed", (done) => {
     dataFetcher.setAuthCredentials({ provider: "test", credentials: "credentials" });
     let providers = [{
-      name: "a provider",
+      id: "a provider",
       plugin: plugin,
       method: "test method"
     }];
@@ -173,7 +173,7 @@ describe("authMiddleware", () => {
     authMiddleware(store)(next)(() => {}).then(() => {
       expect(showAuthFormStub.callCount).to.equal(1);
       expect(showAuthFormStub.args[0][2]).to.deep.equal([{
-        name: "a provider",
+        id: "a provider",
         plugin: plugin,
         method: "test method"
       }]);
@@ -204,7 +204,7 @@ describe("authMiddleware", () => {
 
   it("does not call showAuthForm if there's no supported auth method in the auth document", (done) => {
     store.getState.returns({ auth: {}, collection: {}, book: {} });
-    let authentication = [{ type: "unknown method", description: "a provider" }];
+    let authentication = [{ type: "unknown method", id: "a provider" }];
     let error = {
       status: 401,
       response: JSON.stringify({ title: "Library", authentication })
@@ -220,7 +220,7 @@ describe("authMiddleware", () => {
   it("makes cancel go to previous page if url has changed", (done) => {
     store.getState.returns({ auth: {}, collection: {url: "old"}, book: {} });
     pathFor.returns("new");
-    let authentication = [{ type: "test", description: "a provider" }];
+    let authentication = [{ type: "test", id: "a provider" }];
     let error = {
       status: 401,
       response: JSON.stringify({ title: "Library", authentication })
@@ -241,7 +241,7 @@ describe("authMiddleware", () => {
     store.getState.returns({ auth: {}, collection: {}, book: {} });
     // blank is the value of window.location.pathname when running tests
     pathFor.returns("blank");
-    let authentication = [{ type: "test", description: "a provider" }];
+    let authentication = [{ type: "test", id: "a provider" }];
     let error = {
       status: 401,
       response: JSON.stringify({ name: "Library", authentication })

--- a/packages/opds-web-client/src/__tests__/authMiddleware-test.ts
+++ b/packages/opds-web-client/src/__tests__/authMiddleware-test.ts
@@ -132,17 +132,10 @@ describe("authMiddleware", () => {
 
   it("shows auth form with provider info from failed request if there were no existing credentials", (done) => {
     store.getState.returns({ auth: {}, collection: {}, book: {} });
-    let providers = {
-      provider: {
-        name: "a provider",
-        methods: {
-          test: "test method"
-        }
-      }
-    };
+    let authentication = [{ type: "test", description: "a provider" }];
     let error = {
       status: 401,
-      response: JSON.stringify({ name: "Library", providers: providers })
+      response: JSON.stringify({ title: "Library", authentication })
     };
     next.onCall(1).returns(new Promise((resolve, reject) => { reject(error); }));
     authMiddleware(store)(next)(() => {}).then(() => {
@@ -150,7 +143,7 @@ describe("authMiddleware", () => {
       expect(showAuthFormStub.args[0][2]).to.deep.equal([{
         name: "a provider",
         plugin: plugin,
-        method: "test method"
+        method: authentication[0]
       }]);
       expect(showAuthFormStub.args[0][3]).to.equal("Library");
       done();
@@ -209,19 +202,12 @@ describe("authMiddleware", () => {
     }).catch(err => { console.log(err); throw(err); });
   });
 
-  it("does not call showAuthForm if there's no supported auth method in the provider info", (done) => {
+  it("does not call showAuthForm if there's no supported auth method in the auth document", (done) => {
     store.getState.returns({ auth: {}, collection: {}, book: {} });
-    let providers = {
-      provider: {
-        name: "a provider",
-        methods: {
-          unknownMethod: "unknown method"
-        }
-      }
-    };
+    let authentication = [{ type: "unknown method", description: "a provider" }];
     let error = {
       status: 401,
-      response: JSON.stringify({ name: "Library", providers: providers })
+      response: JSON.stringify({ title: "Library", authentication })
     };
     next.onCall(1).returns(new Promise((resolve, reject) => { reject(error); }));
     authMiddleware(store)(next)(() => {}).then(() => {
@@ -234,17 +220,10 @@ describe("authMiddleware", () => {
   it("makes cancel go to previous page if url has changed", (done) => {
     store.getState.returns({ auth: {}, collection: {url: "old"}, book: {} });
     pathFor.returns("new");
-    let providers = {
-      provider: {
-        name: "a provider",
-        methods: {
-          test: "test method"
-        }
-      }
-    };
+    let authentication = [{ type: "test", description: "a provider" }];
     let error = {
       status: 401,
-      response: JSON.stringify({ name: "Library", providers: providers })
+      response: JSON.stringify({ title: "Library", authentication })
     };
     next.onCall(1).returns(new Promise((resolve, reject) => { reject(error); }));
     authMiddleware(store)(next)(() => {}).then(() => {
@@ -262,17 +241,10 @@ describe("authMiddleware", () => {
     store.getState.returns({ auth: {}, collection: {}, book: {} });
     // blank is the value of window.location.pathname when running tests
     pathFor.returns("blank");
-    let providers = {
-      provider: {
-        name: "a provider",
-        methods: {
-          test: "test method"
-        }
-      }
-    };
+    let authentication = [{ type: "test", description: "a provider" }];
     let error = {
       status: 401,
-      response: JSON.stringify({ name: "Library", providers: providers })
+      response: JSON.stringify({ name: "Library", authentication })
     };
     next.onCall(1).returns(new Promise((resolve, reject) => { reject(error); }));
     authMiddleware(store)(next)(() => {}).then(() => {

--- a/packages/opds-web-client/src/authMiddleware.ts
+++ b/packages/opds-web-client/src/authMiddleware.ts
@@ -49,13 +49,11 @@ export default (authPlugins: AuthPlugin[], pathFor: PathFor) => {
                 // find providers with supported auth method
                 let authProviders: AuthProvider<AuthMethod>[] = [];
                 authPlugins.forEach(plugin => {
-                  let providerKey = data.providers && Object.keys(data.providers).find(key => {
-                    return Object.keys(data.providers[key].methods).indexOf(plugin.type) !== -1;
-                  });
-                  if (providerKey) {
-                    let provider = data.providers[providerKey];
-                    let method = provider.methods[plugin.type];
-                    authProviders.push({ name: provider.name, plugin, method });
+                  for (const method of data.authentication || []) {
+                    if (method.type === plugin.type) {
+                      let name = method.description;
+                      authProviders.push({ name, plugin, method });
+                    }
                   }
                 });
 
@@ -99,7 +97,7 @@ export default (authPlugins: AuthPlugin[], pathFor: PathFor) => {
                     title = state.auth.title;
                     authProviders = state.auth.providers;
                   } else {
-                    title = data.name;
+                    title = data.title;
                   }
 
                   // if previous auth failed and we didn't have any providers

--- a/packages/opds-web-client/src/authMiddleware.ts
+++ b/packages/opds-web-client/src/authMiddleware.ts
@@ -51,8 +51,11 @@ export default (authPlugins: AuthPlugin[], pathFor: PathFor) => {
                 authPlugins.forEach(plugin => {
                   for (const method of data.authentication || []) {
                     if (method.type === plugin.type) {
-                      let name = method.description;
-                      authProviders.push({ name, plugin, method });
+                      // If the authentication provider doesn't have a unique
+                      // identifier, use the method type. This won't work if the
+                      // auth document has two providers with the same method type.
+                      let id = method.id || method.type;
+                      authProviders.push({ id, plugin, method });
                     }
                   }
                 });

--- a/packages/opds-web-client/src/components/AuthProviderSelectionForm.tsx
+++ b/packages/opds-web-client/src/components/AuthProviderSelectionForm.tsx
@@ -35,7 +35,7 @@ export default class AuthProviderSelectionForm extends React.Component<AuthProvi
     let selectedProvider = null;
     if (this.props.error && this.props.attemptedProvider) {
         for (let provider of this.props.providers) {
-            if (this.props.attemptedProvider === provider.name) {
+            if (this.props.attemptedProvider === provider.id) {
                 selectedProvider = provider;
                 break;
             }
@@ -66,7 +66,7 @@ export default class AuthProviderSelectionForm extends React.Component<AuthProvi
             <div>
               <ul className="subtle-list" aria-label="authentication options">
                 { this.props.providers.map(provider =>
-                  <li onClick={() => this.selectProvider(provider)} key={provider.name}>
+                  <li onClick={() => this.selectProvider(provider)} key={provider.id}>
                     <provider.plugin.buttonComponent provider={provider}/>
                   </li>
                 ) }

--- a/packages/opds-web-client/src/components/BasicAuthButton.tsx
+++ b/packages/opds-web-client/src/components/BasicAuthButton.tsx
@@ -4,7 +4,7 @@ import { AuthButtonProps } from "./AuthProviderSelectionForm";
 
 export default class BasicAuthButton extends React.Component<AuthButtonProps<BasicAuthMethod>, void> {
   render() {
-    let label = "Log in with " + this.props.provider.name;
+    let label = this.props.provider.method.description ? "Log in with " + this.props.provider.method.description : "Log in";
 
     return (
       <input type="submit" className="btn btn-default" value={label} />

--- a/packages/opds-web-client/src/components/BasicAuthForm.tsx
+++ b/packages/opds-web-client/src/components/BasicAuthForm.tsx
@@ -81,7 +81,7 @@ export default class BasicAuthForm extends React.Component<BasicAuthFormProps, B
       let credentials = this.generateCredentials(login, password);
 
       this.props.saveCredentials({
-        provider: this.props.provider.name,
+        provider: this.props.provider.id,
         credentials: credentials
       });
       this.props.hide();

--- a/packages/opds-web-client/src/components/__tests__/AuthProviderSelectionForm-test.tsx
+++ b/packages/opds-web-client/src/components/__tests__/AuthProviderSelectionForm-test.tsx
@@ -14,7 +14,7 @@ describe("AuthProviderSelectionForm", () => {
 
   beforeEach(() => {
     provider1 = {
-      name: "Provider 1",
+      id: "Provider 1",
       plugin: BasicAuthPlugin,
       method: {
         labels: {
@@ -25,7 +25,7 @@ describe("AuthProviderSelectionForm", () => {
     };
 
     provider2 = {
-      name: "Provider 2",
+      id: "Provider 2",
       plugin: BasicAuthPlugin,
       method: {
         labels: {

--- a/packages/opds-web-client/src/components/__tests__/BasicAuthButton-test.tsx
+++ b/packages/opds-web-client/src/components/__tests__/BasicAuthButton-test.tsx
@@ -13,9 +13,10 @@ describe("BasicAuthButton", () => {
 
     beforeEach(() => {
       provider = {
-        name: "Test Basic Auth",
+        id: "id",
         plugin: BasicAuthPlugin,
         method: {
+          description: "Test Basic Auth",
           labels: {
             login: "code name",
             password: "secret password"
@@ -32,7 +33,7 @@ describe("BasicAuthButton", () => {
 
     it("shows input with provider name", () => {
       let input = wrapper.find("input");
-      expect(input.prop("value")).to.contain(provider.name);
+      expect(input.prop("value")).to.contain(provider.method.description);
     });
   });
 });

--- a/packages/opds-web-client/src/components/__tests__/BasicAuthForm-test.tsx
+++ b/packages/opds-web-client/src/components/__tests__/BasicAuthForm-test.tsx
@@ -13,9 +13,10 @@ describe("BasicAuthForm", () => {
 
     beforeEach(() => {
       provider = {
-        name: "Test Basic Auth",
+        id: "id",
         plugin: BasicAuthPlugin,
         method: {
+          description: "Test Basic Auth",
           labels: {
             login: "code name",
             password: "secret password"
@@ -75,9 +76,10 @@ describe("BasicAuthForm", () => {
       cancel = stub();
 
       provider = {
-        name: "Test Basic Auth",
+        id: "id",
         plugin: BasicAuthPlugin,
         method: {
+          description: "Test Basic Auth",
           labels: {
             login: "code name",
             password: "secret password"
@@ -145,7 +147,7 @@ describe("BasicAuthForm", () => {
       it("saves credentials", () => {
         expect(saveCredentials.callCount).to.equal(1);
         expect(saveCredentials.args[0][0]).to.deep.equal({
-          provider: "Test Basic Auth",
+          provider: "id",
           credentials: credentials
         });
       });

--- a/packages/opds-web-client/src/interfaces.ts
+++ b/packages/opds-web-client/src/interfaces.ts
@@ -151,13 +151,14 @@ export interface AuthCallback {
 }
 
 export interface AuthProvider<T extends AuthMethod> {
-  name: string;
+  id: string;
   plugin: AuthPlugin;
   method: T;
 }
 
 export interface AuthMethod {
   type: string;
+  description?: string;
 };
 
 export interface AuthData {

--- a/packages/opds-web-client/src/interfaces.ts
+++ b/packages/opds-web-client/src/interfaces.ts
@@ -156,7 +156,9 @@ export interface AuthProvider<T extends AuthMethod> {
   method: T;
 }
 
-export interface AuthMethod {}
+export interface AuthMethod {
+  type: string;
+};
 
 export interface AuthData {
   showForm: boolean;

--- a/packages/opds-web-client/src/reducers/__tests__/auth-test.ts
+++ b/packages/opds-web-client/src/reducers/__tests__/auth-test.ts
@@ -33,6 +33,7 @@ describe("auth reducer", () => {
       name: "library",
       plugin: BasicAuthPlugin,
       method: {
+        type: BasicAuthPlugin.type,
         labels: {
           login: "barcode",
           password: "pin"
@@ -58,6 +59,7 @@ describe("auth reducer", () => {
       name: "library",
       plugin: BasicAuthPlugin,
       method: {
+        type: BasicAuthPlugin.type,
         labels: {
           login: "barcode",
           password: "pin"

--- a/packages/opds-web-client/src/reducers/__tests__/auth-test.ts
+++ b/packages/opds-web-client/src/reducers/__tests__/auth-test.ts
@@ -30,7 +30,7 @@ describe("auth reducer", () => {
     let callback = stub();
     let cancel = stub();
     let provider = {
-      name: "library",
+      id: "library",
       plugin: BasicAuthPlugin,
       method: {
         type: BasicAuthPlugin.type,
@@ -56,7 +56,7 @@ describe("auth reducer", () => {
     let callback = stub();
     let cancel = stub();
     let provider = {
-      name: "library",
+      id: "library",
       plugin: BasicAuthPlugin,
       method: {
         type: BasicAuthPlugin.type,


### PR DESCRIPTION
This fixes #197. I updated the auth middleware to get auth provider information from the new document format. The spec doesn't have a unique identifier for each auth provider, so for now it uses `id` if present but falls back to the method type, and won't work if the method type isn't unique.