### PR TITLE
Updated opds-feed-parser and changed publication date to dc:issued for consistency with OPDS spec.

### DIFF
--- a/packages/opds-web-client/package.json
+++ b/packages/opds-web-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opds-web-client",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "description": "OPDS web client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -26,7 +26,7 @@
     "js-cookie": "^2.1.2",
     "jsdom": "9.9.1",
     "moment": "^2.14.1",
-    "opds-feed-parser": "^0.0.13",
+    "opds-feed-parser": "^0.0.14",
     "prop-types": "^15.6.0",
     "react": "^15.6.2",
     "react-dom": "^15.6.2",

--- a/packages/opds-web-client/src/OPDSDataAdapter.ts
+++ b/packages/opds-web-client/src/OPDSDataAdapter.ts
@@ -146,7 +146,7 @@ export function entryToBook(entry: OPDSEntry, feedUrl: string): BookData {
     holds: holds,
     copies: copies,
     publisher: entry.publisher,
-    published: entry.published && formatDate(entry.published),
+    published: entry.issued && formatDate(entry.issued),
     categories: categories,
     language: entry.language,
     url: detailUrl,

--- a/packages/opds-web-client/src/__tests__/OPDSDataAdaptor-test.ts
+++ b/packages/opds-web-client/src/__tests__/OPDSDataAdaptor-test.ts
@@ -56,7 +56,7 @@ describe("OPDSDataAdapter", () => {
       summary: factory.summary({content: "&lt;b&gt;Sam and Remi Fargo race for treasure&#8212;and survival&#8212;in this lightning-paced new adventure from #1&lt;i&gt; New York Times&lt;/i&gt; bestselling author Clive Cussler.&lt;/b&gt;&lt;br /&gt;&lt;br /&gt;Husband-and-wife team Sam and Remi Fargo are in Mexico when they come upon a remarkable discovery&#8212;the mummified remainsof a man clutching an ancient sealed pot. Within the pot is a Mayan book larger than any known before.&lt;br /&gt;&lt;br /&gt;The book contains astonishing information about the Mayans, their cities, and about mankind itself. The secrets are so powerful that some people would do anything to possess them&#8212;as the Fargos are about to find out. Many men and women are going to die for that book.<script>alert('danger!');</script>"}),
       categories: [factory.category({label: "label"}), factory.category({term: "no label"}), factory.category({label: "label 2"})],
       links: [largeImageLink, thumbImageLink, openAccessLink, borrowLink, fulfillmentLink, collectionLink],
-      published: "2014-06-08T22:45:58Z",
+      issued: "2014-06-08T22:45:58Z",
       publisher: "Fake Publisher",
       series: {
         name: "Fake Series",


### PR DESCRIPTION
See https://github.com/NYPL-Simplified/server_core/pull/769 for explanation.

This depends on https://github.com/NYPL-Simplified/opds-feed-parser/pull/41 and travis tests won't pass until that's merged and published.