### PR TITLE
Wrapping the Collection component instead of rendering the added Coll…

### DIFF
--- a/packages/opds-web-client/package.json
+++ b/packages/opds-web-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opds-web-client",
-  "version": "0.1.19",
+  "version": "0.1.20",
   "description": "OPDS web client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/packages/opds-web-client/src/components/Root.tsx
+++ b/packages/opds-web-client/src/components/Root.tsx
@@ -37,7 +37,7 @@ export interface FooterProps extends React.Props<any> {
   collection: CollectionData;
 }
 
-export interface CollectionHeaderProps extends React.Props<any> {
+export interface CollectionContainerProps extends React.Props<any> {
   facetGroups?: FacetGroupData[];
 }
 
@@ -68,7 +68,7 @@ export interface RootProps extends StateProps {
   fetchPage?: (url: string) => Promise<CollectionData>;
   Header?: new() => __React.Component<HeaderProps, any>;
   Footer?: new() => __React.Component<FooterProps, any>;
-  CollectionHeader?: new() => __React.Component<CollectionHeaderProps, any>;
+  CollectionContainer?: new() => __React.Component<CollectionContainerProps, any>;
   BookDetailsContainer?: new() =>  __React.Component<BookDetailsContainerProps, any>;
   computeBreadcrumbs?: ComputeBreadcrumbs;
   updateBook?: (url: string) => Promise<BookData>;
@@ -105,7 +105,7 @@ export class Root extends React.Component<RootProps, RootState> {
     let BookDetailsContainer = this.props.BookDetailsContainer;
     let Header = this.props.Header;
     let Footer = this.props.Footer;
-    let CollectionHeader = this.props.CollectionHeader;
+    let CollectionContainer = this.props.CollectionContainer;
     let collectionTitle = this.props.collectionData ? this.props.collectionData.title : null;
     let bookTitle = this.props.bookData ? this.props.bookData.title : null;
 
@@ -121,7 +121,7 @@ export class Root extends React.Component<RootProps, RootState> {
     let showFooter = this.props.collectionData && Footer;
     // The tabs should only display if the component is passed and if
     // the catalog is being displayed and not a book.
-    let showCollectionHeader = !!CollectionHeader && !showBook;
+    let showCollectionContainer = !!CollectionContainer && !showBook;
     let facetGroups = this.props.collectionData ?
       this.props.collectionData.facetGroups : [];
 
@@ -184,10 +184,6 @@ export class Root extends React.Component<RootProps, RootState> {
                 />
             }
           </div>
-        }
-
-        { showCollectionHeader &&
-          <CollectionHeader facetGroups={facetGroups} />
         }
 
         <main id="main" className="main" role="main" tabIndex={-1}>
@@ -260,22 +256,40 @@ export class Root extends React.Component<RootProps, RootState> {
               </div>
             }
 
-            { showCollection &&
-              <Collection
-                collection={this.collectionDataWithLoans()}
-                fetchPage={this.props.fetchPage}
-                isFetchingCollection={this.props.isFetchingCollection}
-                isFetchingBook={this.props.isFetchingBook}
-                isFetchingPage={this.props.isFetchingPage}
-                error={this.props.error}
-                updateBook={this.props.updateBook}
-                fulfillBook={this.props.fulfillBook}
-                indirectFulfillBook={this.props.indirectFulfillBook}
-                isSignedIn={this.props.isSignedIn}
-                epubReaderUrlTemplate={this.props.epubReaderUrlTemplate}
-                preferences={this.props.preferences}
-                setPreference={this.props.setPreference}
-                />
+            { showCollection ?
+              (showCollectionContainer ?
+                <CollectionContainer>
+                  <Collection
+                    collection={this.collectionDataWithLoans()}
+                    fetchPage={this.props.fetchPage}
+                    isFetchingCollection={this.props.isFetchingCollection}
+                    isFetchingBook={this.props.isFetchingBook}
+                    isFetchingPage={this.props.isFetchingPage}
+                    error={this.props.error}
+                    updateBook={this.props.updateBook}
+                    fulfillBook={this.props.fulfillBook}
+                    indirectFulfillBook={this.props.indirectFulfillBook}
+                    isSignedIn={this.props.isSignedIn}
+                    epubReaderUrlTemplate={this.props.epubReaderUrlTemplate}
+                    preferences={this.props.preferences}
+                    setPreference={this.props.setPreference}
+                  />
+                </CollectionContainer> :
+                <Collection
+                  collection={this.collectionDataWithLoans()}
+                  fetchPage={this.props.fetchPage}
+                  isFetchingCollection={this.props.isFetchingCollection}
+                  isFetchingBook={this.props.isFetchingBook}
+                  isFetchingPage={this.props.isFetchingPage}
+                  error={this.props.error}
+                  updateBook={this.props.updateBook}
+                  fulfillBook={this.props.fulfillBook}
+                  indirectFulfillBook={this.props.indirectFulfillBook}
+                  isSignedIn={this.props.isSignedIn}
+                  epubReaderUrlTemplate={this.props.epubReaderUrlTemplate}
+                  preferences={this.props.preferences}
+                  setPreference={this.props.setPreference}
+                />) : null
             }
           </div>
         </main>

--- a/packages/opds-web-client/src/components/__tests__/Root-test.tsx
+++ b/packages/opds-web-client/src/components/__tests__/Root-test.tsx
@@ -7,7 +7,7 @@ import { Store } from "redux";
 import { shallow, mount } from "enzyme";
 
 import ConnectedRoot,
-{ Root, BookDetailsContainerProps, HeaderProps, FooterProps, CollectionHeaderProps } from "../Root";
+{ Root, BookDetailsContainerProps, HeaderProps, FooterProps, CollectionContainerProps } from "../Root";
 import Breadcrumbs, { ComputeBreadcrumbs } from "../Breadcrumbs";
 import Collection from "../Collection";
 import UrlForm from "../UrlForm";
@@ -757,8 +757,8 @@ describe("Root", () => {
     });
   });
 
-  describe("provided a CollectionHeader", () => {
-    class Tabs extends React.Component<CollectionHeaderProps, void> {
+  describe("provided a CollectionContainer", () => {
+    class Tabs extends React.Component<CollectionContainerProps, void> {
       render(): JSX.Element {
         return (
           <div className="tabs-container">
@@ -767,7 +767,7 @@ describe("Root", () => {
       }
     }
 
-    describe("No CollectionHeader component rendering", () => {
+    describe("No CollectionContainer component rendering", () => {
       let history: LinkData[] = [{
         id: "2nd id",
         text: "2nd title",
@@ -778,7 +778,7 @@ describe("Root", () => {
         url: "last url"
       }];
 
-      it("should not render CollectionHeader if the component is not passed in", () => {
+      it("should not render CollectionContainer if the component is not passed in", () => {
         let wrapper = shallow(
           <Root
             collectionData={ungroupedCollectionData}
@@ -792,12 +792,25 @@ describe("Root", () => {
         expect(container.length).to.equal(0);
       });
 
-      it("should not render CollectionHeader if the component is passed, but a book is being displayed", () => {
+      it("should not render CollectionContainer if there is no collection data", () => {
+        let wrapper = shallow(
+          <Root
+            history={history}
+            collectionUrl="/test"
+            setCollectionAndBook={mockSetCollectionAndBook}
+          />
+        );
+
+        let container = wrapper.find(Tabs);
+        expect(container.length).to.equal(0);
+      });
+
+      it("should not render CollectionContainer if the component is passed, but a book is being displayed", () => {
         let bookData = groupedCollectionData.lanes[0].books[0];
         let wrapper = shallow(
           <Root
             bookData={bookData}
-            CollectionHeader={Tabs}
+            CollectionContainer={Tabs}
             collectionData={ungroupedCollectionData}
             history={history}
             collectionUrl="/test"
@@ -810,7 +823,7 @@ describe("Root", () => {
       });
     });
 
-    it("renders CollectionHeader", () => {
+    it("renders CollectionContainer", () => {
       let history: LinkData[] = [{
         id: "2nd id",
         text: "2nd title",
@@ -823,8 +836,8 @@ describe("Root", () => {
       let facetGroups = [
         {
           facets: [
-            { label: "Books", href: "http://circulation.librarysimplified.org/groups/?entrypoint=Book", active: false },
-            { label: "Audio", href: "http://circulation.librarysimplified.org/groups/?entrypoint=Audio", active: false },
+            { label: "eBooks", href: "http://circulation.librarysimplified.org/groups/?entrypoint=Book", active: false },
+            { label: "Audiobooks", href: "http://circulation.librarysimplified.org/groups/?entrypoint=Audio", active: false },
           ],
           label: "Formats",
         }
@@ -837,13 +850,12 @@ describe("Root", () => {
           history={history}
           collectionUrl="/test"
           setCollectionAndBook={mockSetCollectionAndBook}
-          CollectionHeader={Tabs}
+          CollectionContainer={Tabs}
         />
       );
 
       let container = wrapper.find(Tabs);
       expect(container.length).to.equal(1);
-      expect(container.props().facetGroups).to.deep.equal(facetGroups);
     });
   });
 });


### PR DESCRIPTION
…ection wrapper separately.

Updated the name of the prop and component and wrapped it around the `Collection` component instead of rendering it separately.

This is part of a refactoring for [circulation-web #159](https://github.com/NYPL-Simplified/circulation-web/pull/159).