### PR TITLE
Adding 'By' before an author(s) name.

### DIFF
--- a/packages/opds-web-client/CHANGELOG.md
+++ b/packages/opds-web-client/CHANGELOG.md
@@ -1,0 +1,5 @@
+## Changelog
+
+### v0.1.22
+#### Added
+- Added "By" before an author(s) name.

--- a/packages/opds-web-client/package.json
+++ b/packages/opds-web-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opds-web-client",
-  "version": "0.1.21",
+  "version": "0.1.22",
   "description": "OPDS web client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/packages/opds-web-client/package.json
+++ b/packages/opds-web-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opds-web-client",
-  "version": "0.1.20",
+  "version": "0.1.21",
   "description": "OPDS web client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/packages/opds-web-client/src/components/Book.tsx
+++ b/packages/opds-web-client/src/components/Book.tsx
@@ -28,38 +28,41 @@ export default class Book<P extends BookProps> extends React.Component<P, void> 
   }
 
   render(): JSX.Element {
+    const book = this.props.book;
     // Remove HTML tags from the summary to fit more information into a truncated view.
     // The summary may still contain HTML character entities and needs to be rendered as HTML.
-    let summary = (this.props.book && this.props.book.summary && this.props.book.summary.replace(/<\/?[^>]+(>|$)/g, " ")) || "";
-    const bookMedium = this.getMedium(this.props.book);
+    let summary = (book && book.summary && book.summary.replace(/<\/?[^>]+(>|$)/g, " ")) || "";
+    const bookMedium = this.getMedium(book);
     const showMediaIconClass = bookMedium ? "show-media" : "";
+    const hasAuthors = !!(book.authors && book.authors.length);
+    const hasContributors = !!(book.contributors && book.contributors.length);
+    const contributors = book.contributors && book.contributors.length ?
+      book.contributors.join(", ") :
+      "";
+    // Display contributors only if there are no authors.
+    const authors = hasAuthors ? book.authors.join(", ") : contributors;
 
     return (
-      <div className={`book ${showMediaIconClass}`} lang={this.props.book.language}>
+      <div className={`book ${showMediaIconClass}`} lang={book.language}>
         <CatalogLink
           collectionUrl={this.props.collectionUrl}
-          bookUrl={this.props.book.url || this.props.book.id}
-          title={this.props.book.title}
+          bookUrl={book.url || book.id}
+          title={book.title}
           >
-          <BookCover book={this.props.book} />
+          <BookCover book={book} />
           <div className={`compact-info ${showMediaIconClass}`}>
             {this.getMediumSVG(bookMedium, false)}
             <div className="empty"></div>
             <div className="item-details">
-              <div className="title">{this.props.book.title}</div>
-              { this.props.book.series && this.props.book.series.name &&
-                <div className="series">{this.props.book.series.name}</div>
+              <div className="title">{book.title}</div>
+              { book.series && book.series.name &&
+                <div className="series">{book.series.name}</div>
               }
-              <div className="authors">
-                <span>By </span>
-                {
-                  this.props.book.authors.length ?
-                  this.props.book.authors.join(", ") :
-                    this.props.book.contributors && this.props.book.contributors.length ?
-                    this.props.book.contributors.join(", ") :
-                    ""
-                }
-              </div>
+              { (hasAuthors || hasContributors) &&
+                <div className="authors">
+                  <span>By {authors}</span>
+                </div>
+              }
             </div>
           </div>
         </CatalogLink>
@@ -68,24 +71,19 @@ export default class Book<P extends BookProps> extends React.Component<P, void> 
             <div>
               <CatalogLink
                 collectionUrl={this.props.collectionUrl}
-                bookUrl={this.props.book.url || this.props.book.id}
-                title={this.props.book.title}
+                bookUrl={book.url || book.id}
+                title={book.title}
                 >
-                  <div className="title">{this.props.book.title}</div>
+                  <div className="title">{book.title}</div>
               </CatalogLink>
-              { this.props.book.series && this.props.book.series.name &&
-                <div className="series">{this.props.book.series.name}</div>
+              { book.series && book.series.name &&
+                <div className="series">{book.series.name}</div>
               }
-              <div className="authors">
-                <span>By </span>
-                {
-                  this.props.book.authors.length ?
-                  this.props.book.authors.join(", ") :
-                    this.props.book.contributors && this.props.book.contributors.length ?
-                    this.props.book.contributors.join(", ") :
-                    ""
-                }
-              </div>
+              { (hasAuthors || hasContributors) &&
+                <div className="authors">
+                  <span>By {authors}</span>
+                </div>
+              }
             </div>
             <div className="circulation-links">
               { this.circulationLinks() }
@@ -102,14 +100,14 @@ export default class Book<P extends BookProps> extends React.Component<P, void> 
                 field.value ? <div className={field.name.toLowerCase().replace(" ", "-")} key={field.name}>{field.name}: {field.value}</div> : null
               ) }
             </div>
-            <div className="summary" lang={this.props.book.language}>
+            <div className="summary" lang={book.language}>
               <span
                 dangerouslySetInnerHTML={{__html: summary}}>
               </span>
               <CatalogLink
                 collectionUrl={this.props.collectionUrl}
-                bookUrl={this.props.book.url || this.props.book.id}
-                title={this.props.book.title}
+                bookUrl={book.url || book.id}
+                title={book.title}
                 >&hellip; More
               </CatalogLink>
             </div>

--- a/packages/opds-web-client/src/components/Book.tsx
+++ b/packages/opds-web-client/src/components/Book.tsx
@@ -51,6 +51,7 @@ export default class Book<P extends BookProps> extends React.Component<P, void> 
                 <div className="series">{this.props.book.series.name}</div>
               }
               <div className="authors">
+                <span>By </span>
                 {
                   this.props.book.authors.length ?
                   this.props.book.authors.join(", ") :
@@ -76,6 +77,7 @@ export default class Book<P extends BookProps> extends React.Component<P, void> 
                 <div className="series">{this.props.book.series.name}</div>
               }
               <div className="authors">
+                <span>By </span>
                 {
                   this.props.book.authors.length ?
                   this.props.book.authors.join(", ") :

--- a/packages/opds-web-client/src/components/BookCover.tsx
+++ b/packages/opds-web-client/src/components/BookCover.tsx
@@ -53,7 +53,9 @@ export default class BookCover extends React.Component<BookCoverProps, BookCover
     return (
       <div className="auto-book-cover" style={{ backgroundColor: bgColor }}>
         <div className="title" style={{ fontSize: titleFontSize }}>{ title }</div>
-        <div className="authors" style={{ fontSize: authorFontSize }}>By { authors.join(", ") }</div>
+        { authors.length &&
+          <div className="authors" style={{ fontSize: authorFontSize }}>By { authors.join(", ") }</div>
+        }
       </div>
     );
   }

--- a/packages/opds-web-client/src/components/BookCover.tsx
+++ b/packages/opds-web-client/src/components/BookCover.tsx
@@ -53,7 +53,7 @@ export default class BookCover extends React.Component<BookCoverProps, BookCover
     return (
       <div className="auto-book-cover" style={{ backgroundColor: bgColor }}>
         <div className="title" style={{ fontSize: titleFontSize }}>{ title }</div>
-        <div className="authors" style={{ fontSize: authorFontSize }}>{ authors.join(", ") }</div>
+        <div className="authors" style={{ fontSize: authorFontSize }}>By { authors.join(", ") }</div>
       </div>
     );
   }

--- a/packages/opds-web-client/src/components/BookDetails.tsx
+++ b/packages/opds-web-client/src/components/BookDetails.tsx
@@ -27,7 +27,7 @@ export default class BookDetails<P extends BookDetailsProps> extends Book<P> {
             }
             {
               this.props.book.authors && this.props.book.authors.length ?
-              <h2 className="authors">{this.props.book.authors.join(", ")}</h2> :
+              <h2 className="authors">By {this.props.book.authors.join(", ")}</h2> :
               ""
             }
             {

--- a/packages/opds-web-client/src/components/__tests__/Book-test.tsx
+++ b/packages/opds-web-client/src/components/__tests__/Book-test.tsx
@@ -147,7 +147,7 @@ describe("Book", () => {
       let authors = bookInfo.find(".authors");
 
       expect(title.text()).to.equal(book.title);
-      expect(authors.text()).to.equal(book.authors.join(", "));
+      expect(authors.text()).to.equal(`By ${book.authors.join(", ")}`);
     });
 
     it("shows contributors when there's no author", () => {
@@ -166,7 +166,7 @@ describe("Book", () => {
       let links = wrapper.find(CatalogLink);
       let bookInfo = links.at(0).children().at(1);
       let authors = bookInfo.find(".authors");
-      expect(authors.text()).to.equal(bookCopy.contributors[0]);
+      expect(authors.text()).to.equal(`By ${bookCopy.contributors[0]}`);
     });
 
     it("renders two icons and labels in the compact and expanded views", () => {
@@ -206,7 +206,7 @@ describe("Book", () => {
       let authors = bookInfo.find(".authors");
 
       expect(title.text()).to.equal(book.title);
-      expect(authors.text()).to.equal(book.authors.join(", "));
+      expect(authors.text()).to.equal(`By ${book.authors.join(", ")}`);
     });
 
     it("shows contributors when there's no author", () => {
@@ -224,7 +224,7 @@ describe("Book", () => {
 
       let bookInfo = wrapper.find(".expanded-info");
       let authors = bookInfo.find(".authors");
-      expect(authors.text()).to.equal(bookCopy.contributors[0]);
+      expect(authors.text()).to.equal(`By ${bookCopy.contributors[0]}`);
     });
 
     it("shows series", () => {

--- a/packages/opds-web-client/src/components/__tests__/BookCover-test.tsx
+++ b/packages/opds-web-client/src/components/__tests__/BookCover-test.tsx
@@ -25,7 +25,7 @@ describe("BookCover", () => {
       expect(title.text()).to.equal(bookData.title);
 
       let authors = wrapper.childAt(1);
-      expect(authors.text()).to.equal(bookData.authors.join(", "));
+      expect(authors.text()).to.equal(`By ${bookData.authors.join(", ")}`);
     });
   });
 
@@ -58,7 +58,7 @@ describe("BookCover", () => {
       expect(title.text()).to.equal(bookData.title);
 
       let authors = wrapper.childAt(1);
-      expect(authors.text()).to.equal(bookData.authors.join(", "));
+      expect(authors.text()).to.equal(`By ${bookData.authors.join(", ")}`);
 
       // The placeholder is cleared when there are new props.
       let newBookData = {

--- a/packages/opds-web-client/src/components/__tests__/BookDetails-test.tsx
+++ b/packages/opds-web-client/src/components/__tests__/BookDetails-test.tsx
@@ -63,7 +63,7 @@ describe("BookDetails", () => {
 
   it("shows authors", () => {
     let author = wrapper.find(".authors");
-    expect(author.text()).to.equal(book.authors.join(", "));
+    expect(author.text()).to.equal(`By ${book.authors.join(", ")}`);
   });
 
   it("shows contributors", () => {


### PR DESCRIPTION
I thought I completed this in a previous PR but I missed it. This covers JIRA ticket [SIMPLY-167](https://jira.nypl.org/browse/SIMPLY-617) - adds "by" before an author(s) name.

@aslagle , found three different cases:

1)
![screen shot 2018-09-20 at 3 47 06 pm](https://user-images.githubusercontent.com/1280564/45843268-23481e00-bced-11e8-831a-78e100408c26.png)
2) 
![screen shot 2018-09-20 at 3 47 11 pm](https://user-images.githubusercontent.com/1280564/45843274-28a56880-bced-11e8-8c18-4d787705e122.png)
3)
![screen shot 2018-09-20 at 3 47 26 pm](https://user-images.githubusercontent.com/1280564/45843279-2c38ef80-bced-11e8-9577-a58839588528.png)
