### PR TITLE
Removing create-react-class dependency and converting component to a …

### DIFF
--- a/packages/opds-web-client/CHANGELOG.md
+++ b/packages/opds-web-client/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Changelog
 
+### v0.1.23
+- Updated the route handler component for the OPDSWebClient component in order to remove the `create-react-class` dependency.
+
 ### v0.1.22
 #### Added
 - Added "By" before an author(s) name.

--- a/packages/opds-web-client/package.json
+++ b/packages/opds-web-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opds-web-client",
-  "version": "0.1.22",
+  "version": "0.1.23",
   "description": "OPDS web client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/packages/opds-web-client/package.json
+++ b/packages/opds-web-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opds-web-client",
-  "version": "0.1.21",
+  "version": "0.1.22",
   "description": "OPDS web client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -19,7 +19,6 @@
   },
   "dependencies": {
     "@nypl/dgx-svg-icons": "^0.3.4",
-    "create-react-class": "^15.6.2",
     "dompurify": "^0.8.1",
     "downloadjs": "^1.4.4",
     "font-awesome": "^4.7.0",

--- a/packages/opds-web-client/src/app.tsx
+++ b/packages/opds-web-client/src/app.tsx
@@ -11,8 +11,12 @@ import AuthPlugin from "./AuthPlugin";
 import "./stylesheets/app.scss";
 
 const OPDSCatalogRouterHandler = (config) => {
+  interface OPDSCatalogParams {
+    collectionUrl: string;
+    bookUrl: string;
+  }
   interface OPDSCatalogProps {
-    params?: any;
+    params?: OPDSCatalogParams;
   }
   class OPDSCatalogRoute extends React.Component<OPDSCatalogProps, void> {
     static contextTypes: {

--- a/packages/opds-web-client/src/app.tsx
+++ b/packages/opds-web-client/src/app.tsx
@@ -10,6 +10,37 @@ import { State } from "./state";
 import AuthPlugin from "./AuthPlugin";
 import "./stylesheets/app.scss";
 
+const OPDSCatalogRouterHandler = (config) => {
+  interface OPDSCatalogProps {
+    params?: any;
+  }
+  class OPDSCatalogRoute extends React.Component<OPDSCatalogProps, void> {
+    static contextTypes: {
+      router: PropTypes.object.isRequired
+    };
+
+    static childContextTypes: React.ValidationMap<void> = {
+      pathFor: PropTypes.func.isRequired
+    };
+
+    getChildContext() {
+      return {
+        pathFor: config.pathFor,
+      };
+    }
+    render() {
+      let { collectionUrl, bookUrl } = this.props.params;
+      let mergedProps: RootProps = Object.assign(config, {
+        collectionUrl,
+        bookUrl
+      });
+      return <OPDSCatalog {...mergedProps} />;
+    };
+  }
+
+  return OPDSCatalogRoute;
+};
+
 /** Standalone app to be mounted in an existing DOM element. */
 class OPDSWebClient {
   elementId: string;
@@ -26,28 +57,7 @@ class OPDSWebClient {
   }, elementId: string) {
     this.elementId = elementId;
     this.pathPattern = config.pathPattern || "/(collection/:collectionUrl/)(book/:bookUrl/)";
-    this.RouteHandler = createReactClass({
-      contextTypes: {
-        router: PropTypes.object.isRequired
-      },
-      childContextTypes: {
-        pathFor: PropTypes.func.isRequired
-      },
-      getChildContext: function() {
-        return {
-          pathFor: config.pathFor
-        };
-      },
-      render: function() {
-        let { collectionUrl, bookUrl } = this.props.params;
-        let mergedProps: RootProps = Object.assign(config, {
-          collectionUrl,
-          bookUrl
-        });
-        return <OPDSCatalog {...mergedProps} />;
-      }
-    });
-
+    this.RouteHandler = OPDSCatalogRouterHandler(config);
     this.render();
   }
 


### PR DESCRIPTION
…class at the root level.

Fixes Jira [SIMPLY-625](https://jira.nypl.org/browse/SIMPLY-625). Converted a component into a class in order to remove the `create-react-class` dependency.