### PR TITLE
Removed hard-coded colors and moved lightening/darkening to overwritable variables

### DIFF
--- a/packages/opds-web-client/CHANGELOG.md
+++ b/packages/opds-web-client/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Changelog
 
+### v0.1.24
+- Removed hard-coded colors and moved lightening/darkening to overwritable variables for compatibility with additional color schemes and CSS variables.
+
 ### v0.1.23
 - Updated the route handler component for the OPDSWebClient component in order to remove the `create-react-class` dependency.
 

--- a/packages/opds-web-client/package.json
+++ b/packages/opds-web-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opds-web-client",
-  "version": "0.1.23",
+  "version": "0.1.24",
   "description": "OPDS web client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/packages/opds-web-client/src/stylesheets/_variables.scss
+++ b/packages/opds-web-client/src/stylesheets/_variables.scss
@@ -14,6 +14,9 @@ $focuscolor: orange !default;
 $pagecolor: $light !default;
 $pagecolorlight: $gray !default;
 $pagetextcolor: $dark !default;
+$pagetextcolorlight: lighten($pagetextcolor, 25%) !default;
+$transparentpagecolor: rgba($pagecolor, 0.5) !default;
+$semitransparentpagecolor: rgba($pagecolor, 0.9) !default;
 $footercolor: #54514A !default;
 $highlightcolor: $darkblue !default;
 

--- a/packages/opds-web-client/src/stylesheets/book_details.scss
+++ b/packages/opds-web-client/src/stylesheets/book_details.scss
@@ -34,7 +34,7 @@
 
     .fields {
       margin-top: 2em;
-      color: #333;
+      color: $pagetextcolor;
       font-size: 1em;
     }
 
@@ -48,6 +48,7 @@
         margin: 0 0 -10px;
         height: 30px;
         width: 30px;
+        fill: $pagetextcolor;
       }
     }
   }

--- a/packages/opds-web-client/src/stylesheets/collection.scss
+++ b/packages/opds-web-client/src/stylesheets/collection.scss
@@ -35,8 +35,8 @@
       }
 
       &:hover:enabled {
-        border-color: lighten($pagetextcolor, 5%);
-        color: lighten($pagetextcolor, 25%);
+        border-color: $pagetextcolorlight;
+        color: $pagetextcolorlight;
       }
     }
   }
@@ -52,7 +52,7 @@
   .empty-collection-message {
     padding: 1em;
     text-align: center;
-    color: #888;
+    color: $pagetextcolor;
     font-size: 3em;
   }
 
@@ -91,11 +91,11 @@
     background-size: $stripeWidth $stripeWidth;
     background-image: linear-gradient(
       45deg,
-      darken($pagecolor, 5%)  25%,
+      $pagecolorlight  25%,
       $pagecolor      25%,
       $pagecolor      50%,
-      darken($pagecolor, 5%)  50%,
-      darken($pagecolor, 5%)  75%,
+      $pagecolorlight  50%,
+      $pagecolorlight  75%,
       $pagecolor      75%,
       $pagecolor
     );

--- a/packages/opds-web-client/src/stylesheets/loading_indicator.scss
+++ b/packages/opds-web-client/src/stylesheets/loading_indicator.scss
@@ -7,11 +7,11 @@
     background-size: $stripeWidth $stripeWidth;
     background-image: linear-gradient(
       45deg,
-      darken($pagecolor, 5%)  25%,
+      $pagecolorlight  25%,
       $pagecolor      25%,
       $pagecolor      50%,
-      darken($pagecolor, 5%)  50%,
-      darken($pagecolor, 5%)  75%,
+      $pagecolorlight  50%,
+      $pagecolorlight  75%,
       $pagecolor      75%,
       $pagecolor
     );

--- a/packages/opds-web-client/src/stylesheets/popup.scss
+++ b/packages/opds-web-client/src/stylesheets/popup.scss
@@ -7,7 +7,7 @@
   width: 100%;
   height: calc(100% - #{$headerHeight});
   z-index: 199;
-  background-color: rgba($pagecolor, 0.5);
+  background-color: $transparentpagecolor;
 
   > * {
     position: fixed;
@@ -17,7 +17,7 @@
     margin-top: 0;
     margin-left: 0;
     padding: 100px;
-    background-color: rgba($pagecolor, 0.9);
+    background-color: $semitransparentpagecolor;
     text-align: center;
     z-index: 200;
     border-radius: 0;

--- a/packages/opds-web-client/src/stylesheets/root.scss
+++ b/packages/opds-web-client/src/stylesheets/root.scss
@@ -9,7 +9,6 @@ html {
 }
 
 body {
-  background-color: $pagecolor;
   font-family: $fontfamily;
   font-size: $basefont;
 }
@@ -72,6 +71,8 @@ a {
   display: flex;
   flex-direction: column;
   height: 100%;
+  background-color: $pagecolor;
+  color: $pagetextcolor;
 
   .navbar-brand {
     font-size: 1.8em;


### PR DESCRIPTION
This supports upcoming changes in circulation-patron-web that will use CSS variables for theming, and support a wider range of color schemes. I removed some hard-coded colors that wouldn't work with certain color schemes and moved lighten/darken calls since they won't work with CSS variables.