### PR TITLE
Modified the AuthProviderSelectionForm to pass a click handler to auth button components instead of putting it on a parent element.

### DIFF
--- a/packages/opds-web-client/CHANGELOG.md
+++ b/packages/opds-web-client/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Changelog
 
+### v0.1.25
+- Modified the AuthProviderSelectionForm to pass a click handler to auth button components instead of putting it on a parent element.
+
 ### v0.1.24
 - Removed hard-coded colors and moved lightening/darkening to overwritable variables for compatibility with additional color schemes and CSS variables.
 

--- a/packages/opds-web-client/package.json
+++ b/packages/opds-web-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opds-web-client",
-  "version": "0.1.24",
+  "version": "0.1.25",
   "description": "OPDS web client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/packages/opds-web-client/src/components/AuthProviderSelectionForm.tsx
+++ b/packages/opds-web-client/src/components/AuthProviderSelectionForm.tsx
@@ -12,6 +12,7 @@ export interface AuthFormProps<T extends AuthMethod> {
 
 export interface AuthButtonProps<T extends AuthMethod> {
   provider?: AuthProvider<T>;
+  onClick?: () => void;
 }
 
 export interface AuthProviderSelectionFormProps {
@@ -68,8 +69,8 @@ export default class AuthProviderSelectionForm extends React.Component<AuthProvi
             <div>
               <ul className="subtle-list" aria-label="authentication options">
                 { this.props.providers.map(provider =>
-                  <li onClick={() => this.selectProvider(provider)} key={provider.id}>
-                    <provider.plugin.buttonComponent provider={provider}/>
+                  <li key={provider.id}>
+                    <provider.plugin.buttonComponent provider={provider} onClick={() => this.selectProvider(provider)}/>
                   </li>
                 ) }
               </ul>

--- a/packages/opds-web-client/src/components/BasicAuthButton.tsx
+++ b/packages/opds-web-client/src/components/BasicAuthButton.tsx
@@ -8,7 +8,7 @@ export default class BasicAuthButton extends React.Component<AuthButtonProps<Bas
     let label = this.props.provider.method.description ? "Log in with " + this.props.provider.method.description : "Log in";
 
     return (
-      <input type="submit" className="btn btn-default" value={label} />
+      <input type="submit" className="btn btn-default" value={label} onClick={this.props.onClick} />
     );
   }
 }

--- a/packages/opds-web-client/src/components/__tests__/BasicAuthButton-test.tsx
+++ b/packages/opds-web-client/src/components/__tests__/BasicAuthButton-test.tsx
@@ -9,7 +9,7 @@ import BasicAuthPlugin from "../../BasicAuthPlugin";
 
 describe("BasicAuthButton", () => {
   describe("rendering", () => {
-    let wrapper, provider;
+    let wrapper, provider, onClick;
 
     beforeEach(() => {
       provider = {
@@ -23,10 +23,12 @@ describe("BasicAuthButton", () => {
           }
         }
       };
+      onClick = stub();
 
       wrapper = shallow(
         <BasicAuthButton
           provider={provider}
+          onClick={onClick}
           />
       );
     });
@@ -34,6 +36,12 @@ describe("BasicAuthButton", () => {
     it("shows input with provider name", () => {
       let input = wrapper.find("input");
       expect(input.prop("value")).to.contain(provider.method.description);
+    });
+
+    it("calls onClick", () => {
+      let input = wrapper.find("input");
+      input.simulate("click");
+      expect(onClick.callCount).to.equal(1);
     });
   });
 });


### PR DESCRIPTION
This is a breaking change for apps built on this that use auth buttons, but that's only circulation-patron-web.