### PR TITLE
Added subtitle and fixed publication date on book details page.

### DIFF
--- a/packages/opds-web-client/CHANGELOG.md
+++ b/packages/opds-web-client/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Changelog
 
+### v0.2.3
+- Added subtitle to the book details page and changed publication date to use UTC so it displays correctly when only date is specified.
+
 ### v0.2.2
 - Updating the app to work with React 16.
 

--- a/packages/opds-web-client/package.json
+++ b/packages/opds-web-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opds-web-client",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "OPDS web client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
@@ -27,7 +27,7 @@
     "js-cookie": "^2.1.2",
     "jsdom": "9.9.1",
     "moment": "^2.14.1",
-    "opds-feed-parser": "^0.0.14",
+    "opds-feed-parser": "^0.0.16",
     "prop-types": "^15.6.0",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",

--- a/packages/opds-web-client/src/OPDSDataAdapter.ts
+++ b/packages/opds-web-client/src/OPDSDataAdapter.ts
@@ -137,6 +137,7 @@ export function entryToBook(entry: OPDSEntry, feedUrl: string): BookData {
     series: entry.series,
     authors: authors,
     contributors: contributors,
+    subtitle: entry.subtitle,
     summary: entry.summary.content && sanitizeHtml(entry.summary.content),
     imageUrl: imageUrl,
     openAccessLinks: openAccessLinks,
@@ -186,10 +187,10 @@ function formatDate(inputDate: string): string {
   ];
 
   let date = new Date(inputDate);
-  let day = date.getDate();
-  let monthIndex = date.getMonth();
+  let day = date.getUTCDate();
+  let monthIndex = date.getUTCMonth();
   let month = monthNames[monthIndex];
-  let year = date.getFullYear();
+  let year = date.getUTCFullYear();
 
   return `${month} ${day}, ${year}`;
 }

--- a/packages/opds-web-client/src/__tests__/OPDSDataAdaptor-test.ts
+++ b/packages/opds-web-client/src/__tests__/OPDSDataAdaptor-test.ts
@@ -52,10 +52,11 @@ describe("OPDSDataAdapter", () => {
       title: "The Mayan Secrets",
       authors: [factory.contributor({name: "Clive Cussler"}), factory.contributor({name: "Thomas Perry"})],
       contributors: [factory.contributor({name: "contributor"})],
+      subtitle: "A Sam and Remi Fargo Adventure",
       summary: factory.summary({content: "&lt;b&gt;Sam and Remi Fargo race for treasure&#8212;and survival&#8212;in this lightning-paced new adventure from #1&lt;i&gt; New York Times&lt;/i&gt; bestselling author Clive Cussler.&lt;/b&gt;&lt;br /&gt;&lt;br /&gt;Husband-and-wife team Sam and Remi Fargo are in Mexico when they come upon a remarkable discovery&#8212;the mummified remainsof a man clutching an ancient sealed pot. Within the pot is a Mayan book larger than any known before.&lt;br /&gt;&lt;br /&gt;The book contains astonishing information about the Mayans, their cities, and about mankind itself. The secrets are so powerful that some people would do anything to possess them&#8212;as the Fargos are about to find out. Many men and women are going to die for that book.<script>alert('danger!');</script>"}),
       categories: [factory.category({label: "label"}), factory.category({term: "no label"}), factory.category({label: "label 2"})],
       links: [largeImageLink, thumbImageLink, openAccessLink, borrowLink, fulfillmentLink, collectionLink],
-      issued: "2014-06-08T22:45:58Z",
+      issued: "2014-06-08",
       publisher: "Fake Publisher",
       series: {
         name: "Fake Series",
@@ -86,6 +87,7 @@ describe("OPDSDataAdapter", () => {
     expect(book.contributors[0]).to.equal(entry.contributors[0].name);
     expect(book.series.name).to.equal(entry.series.name);
     expect(book.series.position).to.equal(entry.series.position);
+    expect(book.subtitle).to.equal(entry.subtitle);
     expect(book.summary).to.equal(sanitizeHtml(entry.summary.content));
     expect(book.summary).to.contain("Many men and women are going to die for that book.");
     expect(book.summary).not.to.contain("script");

--- a/packages/opds-web-client/src/components/BookDetails.tsx
+++ b/packages/opds-web-client/src/components/BookDetails.tsx
@@ -20,24 +20,20 @@ export default class BookDetails<P extends BookDetailsProps> extends Book<P> {
           <div className="header">
             <h1 className="title">{this.props.book.title}</h1>
             {
-              this.props.book.subtitle ?
-              <h3 className="subtitle">{ this.props.book.subtitle }</h3> :
-              ""
+              this.props.book.subtitle &&
+              <h3 className="subtitle">{ this.props.book.subtitle }</h3>
             }
             {
-              this.props.book.series && this.props.book.series.name ?
-              <h3 className="series">{ this.props.book.series.name }</h3> :
-              ""
+              this.props.book.series && this.props.book.series.name &&
+              <h3 className="series">{ this.props.book.series.name }</h3>
             }
             {
-              this.props.book.authors && this.props.book.authors.length ?
-              <h2 className="authors">By {this.props.book.authors.join(", ")}</h2> :
-              ""
+              this.props.book.authors && this.props.book.authors.length &&
+              <h2 className="authors">By {this.props.book.authors.join(", ")}</h2>
             }
             {
-              this.props.book.contributors && this.props.book.contributors.length ?
-              <h2 className="contributors">Contributors: {this.props.book.contributors.join(", ")}</h2> :
-              ""
+              this.props.book.contributors && this.props.book.contributors.length &&
+              <h2 className="contributors">Contributors: {this.props.book.contributors.join(", ")}</h2>
             }
             <div className="fields" lang="en">
               { fields.map(field =>

--- a/packages/opds-web-client/src/components/BookDetails.tsx
+++ b/packages/opds-web-client/src/components/BookDetails.tsx
@@ -20,6 +20,11 @@ export default class BookDetails<P extends BookDetailsProps> extends Book<P> {
           <div className="header">
             <h1 className="title">{this.props.book.title}</h1>
             {
+              this.props.book.subtitle ?
+              <h3 className="subtitle">{ this.props.book.subtitle }</h3> :
+              ""
+            }
+            {
               this.props.book.series && this.props.book.series.name ?
               <h3 className="series">{ this.props.book.series.name }</h3> :
               ""

--- a/packages/opds-web-client/src/components/__tests__/BookDetails-test.tsx
+++ b/packages/opds-web-client/src/components/__tests__/BookDetails-test.tsx
@@ -17,6 +17,7 @@ let book = {
   title: "The Mayan Secrets",
   authors: ["Clive Cussler", "Thomas Perry"],
   contributors: ["contributor 1"],
+  subtitle: "A Sam and Remi Fargo Adventure",
   summary: "&lt;b&gt;Sam and Remi Fargo race for treasure&#8212;and survival&#8212;in this lightning-paced new adventure from #1&lt;i&gt; New York Times&lt;/i&gt; bestselling author Clive Cussler.&lt;/b&gt;&lt;br /&gt;&lt;br /&gt;Husband-and-wife team Sam and Remi Fargo are in Mexico when they come upon a remarkable discovery&#8212;the mummified remainsof a man clutching an ancient sealed pot. Within the pot is a Mayan book larger than any known before.&lt;br /&gt;&lt;br /&gt;The book contains astonishing information about the Mayans, their cities, and about mankind itself. The secrets are so powerful that some people would do anything to possess them&#8212;as the Fargos are about to find out. Many men and women are going to die for that book.",
   imageUrl: "https://dlotdqc6pnwqb.cloudfront.net/3M/crrmnr9/cover.jpg",
   openAccessLinks: [{ url: "secrets.epub", type: "application/epub+zip" }, { url: "secrets.mobi", type: "application/x-mobipocket-ebook" }],
@@ -54,6 +55,11 @@ describe("BookDetails", () => {
   it("shows title", () => {
     let title = wrapper.find(".title");
     expect(title.text()).to.equal(book.title);
+  });
+
+  it("shows subtitle", () => {
+    let subtitle = wrapper.find(".subtitle");
+    expect(subtitle.text()).to.equal(book.subtitle);
   });
 
   it("shows series", () => {

--- a/packages/opds-web-client/src/interfaces.ts
+++ b/packages/opds-web-client/src/interfaces.ts
@@ -9,6 +9,7 @@ export interface BookData {
   };
   authors?: string[];
   contributors?: string[];
+  subtitle?: string;
   summary?: string;
   imageUrl?: string;
   openAccessLinks?: {


### PR DESCRIPTION
This uses https://github.com/NYPL-Simplified/opds-feed-parser/pull/44, which needs to be published before I can deploy a demo or get tests running here.

It fixes a couple things that are confusing in the admin interface - if you add a subtitle in the edit tab, it does not show up on the details tab. And if you add a publication date, it will not have a time, so due to time zones the details tab would display one day before the date you added.