### PR TITLE
Updating the headings on the book detail page.

### DIFF
--- a/packages/opds-web-client/CHANGELOG.md
+++ b/packages/opds-web-client/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Changelog
 
+### v0.2.4
+- Updating the headings on the Book Details page.
+
 ### v0.2.3
 - Added subtitle to the book details page and changed publication date to use UTC so it displays correctly when only date is specified.
 

--- a/packages/opds-web-client/package.json
+++ b/packages/opds-web-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opds-web-client",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "OPDS web client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/packages/opds-web-client/src/components/BookDetails.tsx
+++ b/packages/opds-web-client/src/components/BookDetails.tsx
@@ -44,7 +44,7 @@ export default class BookDetails<P extends BookDetailsProps> extends Book<P> {
               ) }
               {
                 medium && (
-                  <li className="item-icon-container">Format: {this.getMediumSVG(medium)}</li>
+                  <li className="item-icon-container">{this.getMediumSVG(medium)}</li>
                 )
               }
             </ul>

--- a/packages/opds-web-client/src/components/BookDetails.tsx
+++ b/packages/opds-web-client/src/components/BookDetails.tsx
@@ -17,43 +17,43 @@ export default class BookDetails<P extends BookDetailsProps> extends Book<P> {
           <div className="cover">
             <BookCover book={this.props.book} />
           </div>
-          <div className="header">
+          <div className="details">
             <h1 className="title">{this.props.book.title}</h1>
             {
               this.props.book.subtitle &&
-              <h3 className="subtitle">{ this.props.book.subtitle }</h3>
+              <p className="subtitle">{ this.props.book.subtitle }</p>
             }
             {
               this.props.book.series && this.props.book.series.name &&
-              <h3 className="series">{ this.props.book.series.name }</h3>
+              <p className="series">{ this.props.book.series.name }</p>
             }
             {
-              this.props.book.authors && this.props.book.authors.length &&
-              <h2 className="authors">By {this.props.book.authors.join(", ")}</h2>
+              this.props.book.authors && this.props.book.authors.length > 0 &&
+              <p className="authors">By {this.props.book.authors.join(", ")}</p>
             }
             {
-              this.props.book.contributors && this.props.book.contributors.length &&
-              <h2 className="contributors">Contributors: {this.props.book.contributors.join(", ")}</h2>
+              this.props.book.contributors && this.props.book.contributors.length > 0 &&
+              <p className="contributors">Contributors: {this.props.book.contributors.join(", ")}</p>
             }
-            <div className="fields" lang="en">
+            <ul className="fields" lang="en">
               { fields.map(field =>
-                field.value ? <div className={field.name.toLowerCase().replace(" ", "-")} key={field.name}>{field.name}: {field.value}</div> : null
+                field.value &&
+                  <li className={field.name.toLowerCase().replace(" ", "-")} key={field.name}>
+                    {field.name}: {field.value}
+                  </li>
               ) }
-            </div>
-            {
-              medium && (
-                <div className="item-icon-container">{this.getMediumSVG(medium)}</div>
-              )
-            }
+              {
+                medium && (
+                  <li className="item-icon-container">Format: {this.getMediumSVG(medium)}</li>
+                )
+              }
+            </ul>
           </div>
         </div>
         <div className="divider"></div>
-        <div
-          className="main">
+        <div className="main">
           <div className="row">
-            <div className="col-sm-3">
-            </div>
-            <div className="top col-sm-6">
+            <div className="top col-sm-6 col-sm-offset-3">
               <div className="circulation-links">
                 { this.circulationLinks() }
               </div>
@@ -66,6 +66,7 @@ export default class BookDetails<P extends BookDetailsProps> extends Book<P> {
             </div>
           </div>
 
+          <h2>Summary</h2> 
           <div className="summary" lang={this.props.book.language}
                dangerouslySetInnerHTML={{ __html: this.props.book.summary }}></div>
         </div>

--- a/packages/opds-web-client/src/components/__tests__/BookDetails-test.tsx
+++ b/packages/opds-web-client/src/components/__tests__/BookDetails-test.tsx
@@ -87,7 +87,7 @@ describe("BookDetails", () => {
     let svg = itemIcon.find(AudioHeadphoneIcon);
 
     expect(svg.length).to.equal(1);
-    expect(itemIcon.render().text()).to.equal("Audio/Headphone Icon Audio");
+    expect(itemIcon.render().text()).to.equal("Format: Audio/Headphone Icon Audio");
   });
 
   it("doesn't show publisher when there isn't one", () => {

--- a/packages/opds-web-client/src/components/__tests__/BookDetails-test.tsx
+++ b/packages/opds-web-client/src/components/__tests__/BookDetails-test.tsx
@@ -87,7 +87,7 @@ describe("BookDetails", () => {
     let svg = itemIcon.find(AudioHeadphoneIcon);
 
     expect(svg.length).to.equal(1);
-    expect(itemIcon.render().text()).to.equal("Format: Audio/Headphone Icon Audio");
+    expect(itemIcon.render().text()).to.equal("Audio/Headphone Icon Audio");
   });
 
   it("doesn't show publisher when there isn't one", () => {

--- a/packages/opds-web-client/src/stylesheets/book_details.scss
+++ b/packages/opds-web-client/src/stylesheets/book_details.scss
@@ -1,5 +1,3 @@
-@import "variables";
-
 .book-details {
   .top {
     display: table-row;
@@ -12,7 +10,7 @@
     vertical-align: top;
   }
 
-  .header {
+  .details {
     display: table-cell;
     vertical-align: top;
     text-align: left;
@@ -22,20 +20,24 @@
       margin: 0px;
     }
 
-    h3 {
+    .subtitle,
+    .series {
       margin-top: 0.5em;
       font-size: 1.5em;
     }
 
-    h2 {
+    .authors,
+    .contributors {
       margin-top: 0.5em;
-      font-size: 1.5em;
+      font-size: 1.2em;
     }
 
     .fields {
-      margin-top: 2em;
+      margin-top: 1em;
       color: $pagetextcolor;
       font-size: 1em;
+      list-style: none;
+      padding-left: 0;
     }
 
     .item-icon-container {


### PR DESCRIPTION
Minor updates for https://jira.nypl.org/browse/SIMPLY-2023. From a conversation with Willa, the current headings don't define any sections so they don't need to be headings. The summary section does need a heading so I added one there. There are also a few CSS updates and the book details is now a list.