### PR TITLE
"scrollLeft" bug fix

### DIFF
--- a/packages/opds-web-client/CHANGELOG.md
+++ b/packages/opds-web-client/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### v0.2.9
 - Fixed function binding issue that caused a TypeError when resizing the window.
+- Added error handler in DataFetcher if an adapter is not configured.
 
 ### v0.2.8
 - Added Typedoc for code documentation of React components and related classes and functions.

--- a/packages/opds-web-client/CHANGELOG.md
+++ b/packages/opds-web-client/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Changelog
 
+### v0.2.9
+- Fixed function binding issue that caused a TypeError when resizing the window.
+
 ### v0.2.8
 - Added Typedoc for code documentation of React components and related classes and functions.
 

--- a/packages/opds-web-client/package.json
+++ b/packages/opds-web-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opds-web-client",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "description": "OPDS web client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/packages/opds-web-client/src/DataFetcher.ts
+++ b/packages/opds-web-client/src/DataFetcher.ts
@@ -37,10 +37,22 @@ export default class DataFetcher {
     this.proxyUrl = config.proxyUrl;
     this.adapter = config.adapter;
     this.authKey = "authCredentials";
+
+    if (!this.adapter) {
+      console.error("No adapter has been configured.");
+    }
   }
 
   fetchOPDSData(url: string) {
     let parser = new OPDSParser;
+
+    if (!this.adapter) {
+      return Promise.reject({
+        status: null,
+        response: "No adapter has been configured in DataFetcher.",
+        url
+      });
+    }
 
     return new Promise((resolve, reject: RequestRejector) => {
       this.fetch(url).then(response => {

--- a/packages/opds-web-client/src/components/Lane.tsx
+++ b/packages/opds-web-client/src/components/Lane.tsx
@@ -28,6 +28,7 @@ export default class Lane extends React.Component<LaneProps, LaneState> {
     this.state = { atLeft: true, atRight: false };
     this.scrollBack = this.scrollBack.bind(this);
     this.scrollForward = this.scrollForward.bind(this);
+    this.updateScrollButtons = this.updateScrollButtons.bind(this);
   }
 
   render(): JSX.Element {
@@ -182,8 +183,8 @@ export default class Lane extends React.Component<LaneProps, LaneState> {
   componentDidMount() {
     let list = this.refs["list"] as any;
     if (list) {
-      list.addEventListener("scroll", this.updateScrollButtons.bind(this));
-      window.addEventListener("resize", this.updateScrollButtons.bind(this));
+      list.addEventListener("scroll", this.updateScrollButtons);
+      window.addEventListener("resize", this.updateScrollButtons);
       this.updateScrollButtons();
     }
   }
@@ -191,8 +192,8 @@ export default class Lane extends React.Component<LaneProps, LaneState> {
   componentWillUnmount() {
     let list = this.refs["list"] as any;
     if (list) {
-      list.removeEventListener("scroll", this.updateScrollButtons.bind(this));
-      window.removeEventListener("resize", this.updateScrollButtons.bind(this));
+      list.removeEventListener("scroll", this.updateScrollButtons);
+      window.removeEventListener("resize", this.updateScrollButtons);
     }
   }
 }

--- a/packages/opds-web-client/src/components/Root.tsx
+++ b/packages/opds-web-client/src/components/Root.tsx
@@ -123,9 +123,13 @@ export class Root extends React.Component<RootProps, RootState> {
     // The tabs should only display if the component is passed and if
     // the catalog is being displayed and not a book.
     let showCollectionContainer = !!CollectionContainer && !showBook;
-    let facetGroups = this.props.collectionData ?
-      this.props.collectionData.facetGroups : [];
     let allLanguageSearch = this.props.allLanguageSearch;
+    let hasError = this.props.error && (!this.props.auth || !this.props.auth.showForm);
+    let errorMessage = "";
+    if (hasError) {
+      errorMessage = `Could not fetch data: ${this.props.error.url}\n
+        ${this.props.error.response}`;
+    }
 
     return (
       <div className="catalog">
@@ -198,9 +202,9 @@ export class Root extends React.Component<RootProps, RootState> {
               close={() => { this.setState({ authError: null }); }} />
           }
 
-          { this.props.error && (!this.props.auth || !this.props.auth.showForm) &&
+          { hasError &&
             <ErrorMessage
-              message={"Could not fetch data: " + this.props.error.url}
+              message={errorMessage}
               retry={this.props.retryCollectionAndBook} />
           }
 

--- a/packages/opds-web-client/src/components/__tests__/Root-test.tsx
+++ b/packages/opds-web-client/src/components/__tests__/Root-test.tsx
@@ -299,6 +299,7 @@ describe("Root", () => {
 
     let error = wrapper.find(ErrorMessage);
     expect(error.props().message).to.contain(fetchError.url);
+    expect(error.props().message).to.contain(fetchError.response);
     expect(error.props().retry).to.equal(retry);
   });
 

--- a/packages/opds-web-client/src/components/mergeRootProps.ts
+++ b/packages/opds-web-client/src/components/mergeRootProps.ts
@@ -2,7 +2,6 @@ import ActionsCreator from "../actions";
 import DataFetcher from "../DataFetcher";
 import { adapter } from "../OPDSDataAdapter";
 import { CollectionData, BookData, AuthCallback, AuthCredentials } from "../interfaces";
-import { State } from "../state";
 
 export function findBookInCollection(collection: CollectionData, book: string) {
   if (collection) {

--- a/packages/opds-web-client/src/stylesheets/error_message.scss
+++ b/packages/opds-web-client/src/stylesheets/error_message.scss
@@ -13,6 +13,7 @@
   .message {
     overflow: auto;
     padding-bottom: 10px;
+    white-space: pre;
   }
 
   .btn {


### PR DESCRIPTION
Binding a function to the class so it can properly be removed when the component unmounts.

Resolves [SIMPLY-603](https://jira.nypl.org/browse/SIMPLY-603). The fix was simply but hard to find. This fixes the console error we kept seeing:
![Screen Shot 2019-10-30 at 11 02 36 AM](https://user-images.githubusercontent.com/1280564/67870287-fcba0080-fb04-11e9-8aea-7879474ef15a.png)

This happens on any page that is not the main catalog. The function `updateScrollButtons` was being added as `this.updateScrollButtons.bind(this)` when trying to remove it as an event listener from `window`. I'm not exactly sure if the issue is that it created a new instance of that function or, because it wasn't a named function, that attempting to remove it simply didn't work. I'm sure the latter reason is the right one (but not binding functions in loops or directly in inline `onClick` functions can create new instances of the function).

I think the bigger issue which I was trying to resolve is that the `Collection` component gets rendered even when it's not needed. So on a book page, the `Collection` component renders, which causes the `Lane` component to mount and unmount and that's when this issue occurs. It doesn't seem to be trivial to simply not render the Collection component but will attempt to update that later.