### PR TITLE
Adding a loadCollection action to load any loans collection data…

### DIFF
--- a/packages/opds-web-client/CHANGELOG.md
+++ b/packages/opds-web-client/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### v0.2.9
 - Fixed function binding issue that caused a TypeError when resizing the window.
 - Added error handler in DataFetcher if an adapter is not configured.
+- Improved the speed of the "My Books" page by storing the loans collection data in the store and loading it called.
 
 ### v0.2.8
 - Added Typedoc for code documentation of React components and related classes and functions.

--- a/packages/opds-web-client/src/__tests__/actions-test.ts
+++ b/packages/opds-web-client/src/__tests__/actions-test.ts
@@ -312,6 +312,24 @@ describe("actions", () => {
     });
   });
 
+  describe("loadCollection", () => {
+    it("dispatches request, load, and success", async () => {
+      const loansData: CollectionData = {
+        id: "loans",
+        url: "loans url",
+        title: "loans title",
+        lanes: [],
+        books: [],
+        navigationLinks: []
+      };
+      const action = await mockActions.loadCollection(loansData);
+
+      expect(action.type).to.equal(`${ActionCreator.COLLECTION}_${ActionCreator.LOAD}`);
+      expect(action.url).to.equal(undefined);
+      expect(action.data).to.equal(loansData);
+    });
+  });
+
   describe("fetchPage", () => {
     it("dispatches request, success, and load", async () => {
       let dispatch = stub();

--- a/packages/opds-web-client/src/actions.ts
+++ b/packages/opds-web-client/src/actions.ts
@@ -189,6 +189,9 @@ export default class ActionCreator {
     return { type: `${type}_${ActionCreator.CLEAR}` };
   }
 
+  loadCollection(data: CollectionData) {
+    return this.load<CollectionData>(ActionCreator.COLLECTION, data);
+  }
 
   fetchCollection(url: string) {
     return this.fetchOPDS<CollectionData>(ActionCreator.COLLECTION, url);

--- a/packages/opds-web-client/src/components/Book.tsx
+++ b/packages/opds-web-client/src/components/Book.tsx
@@ -208,7 +208,7 @@ export default class Book<P extends BookProps> extends React.Component<P, {}> {
       );
       links.push(
         <BorrowButton
-          key={this.props.book.borrowUrl}
+          key={`${this.props.book.borrowUrl}-borrow-button`}
           className="btn btn-default borrowed-button"
           disabled={true}
           borrow={this.borrow}>

--- a/packages/opds-web-client/src/components/mergeRootProps.ts
+++ b/packages/opds-web-client/src/components/mergeRootProps.ts
@@ -29,6 +29,7 @@ export function mapStateToProps(state, ownProps) {
     collectionUrl: ownProps.collectionUrl,
     bookUrl: ownProps.bookUrl,
     loansUrl: state.loans.url,
+    loansData: state.loans.loansData,
     loans: state.loans.books,
     auth: state.auth,
     isSignedIn: !!state.auth.credentials,
@@ -45,6 +46,7 @@ export function mapDispatchToProps(dispatch) {
         fetchPage: (url: string) => dispatch(actions.fetchPage(url)),
         fetchBook: (url: string) => dispatch(actions.fetchBook(url)),
         loadBook: (book: BookData, url: string) => dispatch(actions.loadBook(book, url)),
+        loadCollection: (data: CollectionData) => dispatch(actions.loadCollection(data)),
         clearCollection: () => dispatch(actions.clearCollection()),
         clearBook: () => dispatch(actions.clearBook()),
         fetchSearchDescription: (url: string) => dispatch(actions.fetchSearchDescription(url)),
@@ -120,6 +122,15 @@ export function mergeRootProps(stateProps, createDispatchProps, componentProps) 
         } else {
           resolve(stateProps.collectionData);
         }
+      } else if (url === stateProps.loansUrl && stateProps.loans.length) {
+        const loansData = Object.assign({}, stateProps.loansData);
+        // Need to keep the existing breadcrumb link and in order to do so,
+        // a new object is created for the loan collection.
+        loansData["catalogRootLink"] = stateProps.collectionData.catalogRootLink;
+        // Need to clear the current collection first.
+        dispatchProps.clearCollection();
+        dispatchProps.loadCollection(loansData);
+        resolve(stateProps.loansData);
       } else {
         // if url is changed, either fetch or clear collection
         if (url) {

--- a/packages/opds-web-client/src/reducers/__tests__/loans-test.ts
+++ b/packages/opds-web-client/src/reducers/__tests__/loans-test.ts
@@ -33,7 +33,8 @@ let loansData = {
 describe("loans reducer", () => {
   let initState = {
     url: null,
-    books: []
+    books: [],
+    loansData: {}
   };
 
   it("returns the initial state", () => {
@@ -50,14 +51,14 @@ describe("loans reducer", () => {
     let oldState = { ...initState, url: "loans url" };
     let loansCollectionData = { ...collectionData, books: loansData.books };
     let action = actions.load<CollectionData>(ActionCreator.COLLECTION, loansCollectionData, "loans url");
-    let newState = { ...oldState, books: loansData.books };
+    let newState = { ...oldState, books: loansData.books, loansData: loansCollectionData };
     expect(reducer(oldState, action)).to.deep.equal(newState);
   });
 
   it("handles LOANS_LOAD", () => {
     let oldState = { ...initState, url: "loans url" };
     let action = actions.load<CollectionData>(ActionCreator.LOANS, loansData);
-    let newState = { ...oldState, books: loansData.books };
+    let newState = { ...oldState, books: loansData.books, loansData: loansData };
 
     expect(reducer(oldState, action)).to.deep.equal(newState);
   });

--- a/packages/opds-web-client/src/reducers/loans.ts
+++ b/packages/opds-web-client/src/reducers/loans.ts
@@ -4,11 +4,13 @@ import ActionCreator from "../actions";
 export interface LoansState {
   url: string;
   books: BookData[];
+  loansData: any;
 }
 
 const initialState: LoansState = {
   url: null,
-  books: []
+  books: [],
+  loansData: {},
 };
 
 export default (state: LoansState = initialState, action): LoansState => {
@@ -19,17 +21,18 @@ export default (state: LoansState = initialState, action): LoansState => {
 
       return {
         ...state,
-        url: action.data.shelfUrl || state.url,
-        books: isLoans ? action.data.books : state.books
+        url: loansUrl,
+        books: isLoans ? action.data.books : state.books,
+        loansData: isLoans ? action.data : state.loansData,
       };
 
     case ActionCreator.LOANS_LOAD:
-      return { ...state, books: action.data.books };
+      return { ...state, books: action.data.books, loansData: action.data };
 
     case ActionCreator.CLEAR_AUTH_CREDENTIALS:
       // Clear auth credentials should remove the authenticated
       // user's loans as well.
-      return {...state, books: [] };
+      return { ...state, books: [] };
 
     case ActionCreator.UPDATE_BOOK_LOAD:
       // A book has been updated, so the loans feed is now outdated.


### PR DESCRIPTION
…which was already fetch to improve performance.

Resolves [SIMPLY-613](https://jira.nypl.org/browse/SIMPLY-613). Adding this update to the existing unpublished version 0.2.9.

When a loans collection is fetched, it will be saved in the store. Then, when attempting to fetch the same loans url, instead of making a new request, it will load the loans collection. There is some speed improvements when going back and forth between the catalog and the "My Books" tab.

Two things concern me:
1) The catalog breadcrumbs gets lost so I am using the current (catalog collection) breadcrumb location url and adding it to the loans collection object. Otherwise, it would be as if you go directly to the "My Books" (loans) page and there is no way to go to the catalog.
2) If you borrow a book, the books in the loans collection will correctly update so there is no need to make a new request. The only issue is that it takes about 1-2 seconds for that process to happen right after clicking "borrow" on a book. So a user decides to borrow a book and then right away go to the "My Books" loans tab, the book won't appear. Not sure how often that will happen but if the user then goes to the catalog and back again, the book will reappear. This isn't an issue if a user clicks on "borrow" and then takes their time to go to the loans page.

The best way to test would be by signing into your library and borrow some books.