### PR TITLE
Type fixes and logic extraction

### DIFF
--- a/packages/opds-web-client/CHANGELOG.md
+++ b/packages/opds-web-client/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## Changelog
 
+### v0.3.3
+
+- created a hook called `usePathFor` to consume `PathFor` context
+- extracted `DownloadButton` logic for use in circulation-patron-web
+- made many properties optional because they were already effectively optional, only this
+  repo didn't have `strictNullChecks` turned on, while circulation-patron-web now does
+- make `OpenAccessLinksType` string literal type for better checking and autofill
+
 ### v0.3.2
 
 - Pass the redux store down the tree via context

--- a/packages/opds-web-client/package-lock.json
+++ b/packages/opds-web-client/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "opds-web-client",
-  "version": "0.3.0",
+  "version": "0.3.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -9445,17 +9445,6 @@
             "tslib": "^1.8.1"
           }
         }
-      }
-    },
-    "tslint-plugin-prettier": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/tslint-plugin-prettier/-/tslint-plugin-prettier-2.0.1.tgz",
-      "integrity": "sha512-4FX9JIx/1rKHIPJNfMb+ooX1gPk5Vg3vNi7+dyFYpLO+O57F4g+b/fo1+W/G0SUOkBLHB/YKScxjX/P+7ZT/Tw==",
-      "dev": true,
-      "requires": {
-        "eslint-plugin-prettier": "^2.2.0",
-        "lines-and-columns": "^1.1.6",
-        "tslib": "^1.7.1"
       }
     },
     "tslint-plugin-prettier": {

--- a/packages/opds-web-client/package.json
+++ b/packages/opds-web-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opds-web-client",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "OPDS web client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/packages/opds-web-client/src/AuthPlugin.ts
+++ b/packages/opds-web-client/src/AuthPlugin.ts
@@ -13,7 +13,7 @@ interface AuthPlugin {
     credentials?: AuthCredentials;
     error?: string;
   } | void;
-  formComponent: new (props: AuthFormProps<AuthMethod>) => React.Component<
+  formComponent?: new (props: AuthFormProps<AuthMethod>) => React.Component<
     AuthFormProps<AuthMethod>,
     {}
   >;

--- a/packages/opds-web-client/src/components/DownloadButton.tsx
+++ b/packages/opds-web-client/src/components/DownloadButton.tsx
@@ -92,15 +92,6 @@ export default class DownloadButton extends React.Component<
     );
   }
 
-  generateFilename(str: string): string {
-    return (
-      str
-        .toLowerCase()
-        .replace(/[^a-z0-9]+/g, "-")
-        .replace(/(^-|-$)/g, "") + this.fileExtension()
-    );
-  }
-
   mimeType() {
     return this.props.mimeType === "vnd.adobe/adept+xml"
       ? "application/vnd.adobe.adept+xml"
@@ -108,6 +99,9 @@ export default class DownloadButton extends React.Component<
   }
 
   fileExtension() {
+    // this ?? syntax is similar to x || y, except that it will only
+    // fall back if the predicate is undefined or null, not if it
+    // is falsy (false, 0, etc).
     return typeMap[this.mimeType()]?.extension ?? "";
   }
 

--- a/packages/opds-web-client/src/components/DownloadButton.tsx
+++ b/packages/opds-web-client/src/components/DownloadButton.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import download from "./download";
+import { typeMap, generateFilename } from "../utils/file";
 
 export interface DownloadButtonProps extends React.HTMLProps<{}> {
   url: string;
@@ -75,7 +76,7 @@ export default class DownloadButton extends React.Component<
       return this.props.fulfill(this.props.url).then(blob => {
         download(
           blob,
-          this.generateFilename(this.props.title),
+          generateFilename(this.props.title, this.fileExtension()),
           // TODO: use mimeType variable once we fix the link type in our OPDS entries
           this.mimeType()
         );
@@ -107,14 +108,7 @@ export default class DownloadButton extends React.Component<
   }
 
   fileExtension() {
-    return (
-      {
-        "application/epub+zip": ".epub",
-        "application/pdf": ".pdf",
-        "application/vnd.adobe.adept+xml": ".acsm",
-        "application/x-mobipocket-ebook": ".mobi"
-      }[this.mimeType()] || ""
-    );
+    return typeMap[this.mimeType()]?.extension ?? "";
   }
 
   downloadLabel() {
@@ -124,9 +118,8 @@ export default class DownloadButton extends React.Component<
     ) {
       return "Read Online";
     }
-    let type = this.fileExtension()
-      .replace(".", "")
-      .toUpperCase();
+    let type = typeMap[this.mimeType()]?.name;
+
     return "Download" + (type ? " " + type : "");
   }
 }

--- a/packages/opds-web-client/src/components/__tests__/BookDetails-test.tsx
+++ b/packages/opds-web-client/src/components/__tests__/BookDetails-test.tsx
@@ -10,8 +10,9 @@ import BookDetails from "../BookDetails";
 import BookCover from "../BookCover";
 import BorrowButton from "../BorrowButton";
 import DownloadButton from "../DownloadButton";
+import { BookData } from "../../interfaces";
 
-let book = {
+let book: BookData = {
   id: "urn:librarysimplified.org/terms/id/3M%20ID/crrmnr9",
   url: "http://circulation.librarysimplified.org/works/3M/crrmnr9",
   title: "The Mayan Secrets",

--- a/packages/opds-web-client/src/components/__tests__/DownloadButton-test.tsx
+++ b/packages/opds-web-client/src/components/__tests__/DownloadButton-test.tsx
@@ -43,7 +43,7 @@ describe("DownloadButton", () => {
   it("shows button", () => {
     let button = wrapper.find("button");
     expect(button.props().style).to.deep.equal(style);
-    expect(button.text()).to.equal("Download ePub");
+    expect(button.text()).to.equal("Download EPUB");
   });
 
   it("shows plain link if specified", () => {
@@ -51,7 +51,7 @@ describe("DownloadButton", () => {
     let link = wrapper.find("a");
     expect(link.props().style).to.deep.equal(style);
     expect(link.props().href).to.equal("download url");
-    expect(link.text()).to.equal("Download ePub");
+    expect(link.text()).to.equal("Download EPUB");
   });
 
   it("fulfills when clicked", () => {

--- a/packages/opds-web-client/src/components/__tests__/DownloadButton-test.tsx
+++ b/packages/opds-web-client/src/components/__tests__/DownloadButton-test.tsx
@@ -6,6 +6,7 @@ const downloadMock = require("../../__mocks__/downloadjs");
 
 import * as React from "react";
 import { shallow } from "enzyme";
+import { generateFilename, typeMap } from "../../utils/file";
 
 import DownloadButton from "../DownloadButton";
 
@@ -15,6 +16,9 @@ describe("DownloadButton", () => {
   let indirectFulfill;
   let style;
   let downloadStub;
+
+  const mimeType = "application/epub+zip";
+  const title = "title";
 
   beforeEach(() => {
     downloadStub = stub(download, "default").callsFake(downloadMock);
@@ -28,10 +32,10 @@ describe("DownloadButton", () => {
       <DownloadButton
         style={style}
         url="download url"
-        mimeType="application/epub+zip"
+        mimeType={mimeType}
         fulfill={fulfill}
         indirectFulfill={indirectFulfill}
-        title="title"
+        title={title}
       />
     );
   });
@@ -69,7 +73,7 @@ describe("DownloadButton", () => {
       .then(() => {
         expect(downloadMock.getBlob()).to.equal("blob");
         expect(downloadMock.getFilename()).to.equal(
-          wrapper.instance().generateFilename("title")
+          generateFilename(title, typeMap[mimeType].extension)
         );
         expect(downloadMock.getMimeType()).to.equal(
           wrapper.instance().mimeType()

--- a/packages/opds-web-client/src/components/__tests__/DownloadButton-test.tsx
+++ b/packages/opds-web-client/src/components/__tests__/DownloadButton-test.tsx
@@ -43,7 +43,7 @@ describe("DownloadButton", () => {
   it("shows button", () => {
     let button = wrapper.find("button");
     expect(button.props().style).to.deep.equal(style);
-    expect(button.text()).to.equal("Download EPUB");
+    expect(button.text()).to.equal("Download ePub");
   });
 
   it("shows plain link if specified", () => {
@@ -51,7 +51,7 @@ describe("DownloadButton", () => {
     let link = wrapper.find("a");
     expect(link.props().style).to.deep.equal(style);
     expect(link.props().href).to.equal("download url");
-    expect(link.text()).to.equal("Download EPUB");
+    expect(link.text()).to.equal("Download ePub");
   });
 
   it("fulfills when clicked", () => {

--- a/packages/opds-web-client/src/components/context/PathForContext.tsx
+++ b/packages/opds-web-client/src/components/context/PathForContext.tsx
@@ -33,3 +33,11 @@ export default class PathForProvider extends React.Component<PathForProps> {
     );
   }
 }
+
+export function usePathFor() {
+  const context = React.useContext(PathForContext);
+  if (typeof context === "undefined") {
+    throw new Error("usePathFor must be used within a PathForProvider");
+  }
+  return context;
+}

--- a/packages/opds-web-client/src/components/context/RouterContext.tsx
+++ b/packages/opds-web-client/src/components/context/RouterContext.tsx
@@ -15,7 +15,6 @@ export const RouterContext = React.createContext<RouterType>(null);
 
 type RouterContextProps = {
   router: RouterType;
-  children: React.ReactChild;
 };
 
 export default class RouterProvider extends React.Component<

--- a/packages/opds-web-client/src/components/context/StoreContext.tsx
+++ b/packages/opds-web-client/src/components/context/StoreContext.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { Provider } from "react-redux";
+import { Provider, ReactReduxContext } from "react-redux";
 import * as Redux from "redux";
 import { State } from "../../state";
 import AuthPlugin from "../../AuthPlugin";
@@ -7,10 +7,10 @@ import buildStore from "../../store";
 import { PathForContext } from "./PathForContext";
 import BasicAuthPlugin from "../../BasicAuthPlugin";
 
-type OPDSStoreProps = {
-  children: React.ReactElement;
+export type OPDSStoreProps = {
   initialState?: State;
   authPlugins?: AuthPlugin[];
+  children: React.ReactNode;
 };
 /**
  * Builds the redux store and makes it available in context via new API.
@@ -36,3 +36,5 @@ export default class OPDSStore extends React.Component<OPDSStoreProps> {
     return <Provider store={this.store}>{this.props.children}</Provider>;
   }
 }
+
+export const ReduxContext = ReactReduxContext;

--- a/packages/opds-web-client/src/interfaces.ts
+++ b/packages/opds-web-client/src/interfaces.ts
@@ -117,7 +117,7 @@ export interface StateProps {
 }
 
 export interface PathFor {
-  (collectionUrl: string, bookUrl: string): string;
+  (collectionUrl?: string, bookUrl?: string): string;
 }
 
 export interface FetchErrorData {

--- a/packages/opds-web-client/src/interfaces.ts
+++ b/packages/opds-web-client/src/interfaces.ts
@@ -1,5 +1,12 @@
 import AuthPlugin from "./AuthPlugin";
 
+export type OpenAccessLinkType =
+  | "application/epub+zip"
+  | "application/pdf"
+  | "application/vnd.adobe.adept+xml"
+  | "application/x-mobipocket-ebook"
+  | "application/x-mobi8-ebook";
+
 export interface BookData {
   id: string;
   title: string;
@@ -14,7 +21,7 @@ export interface BookData {
   imageUrl?: string;
   openAccessLinks?: {
     url: string;
-    type: string;
+    type: OpenAccessLinkType;
   }[];
   borrowUrl?: string;
   fulfillmentLinks?: {

--- a/packages/opds-web-client/src/reducers/collection.ts
+++ b/packages/opds-web-client/src/reducers/collection.ts
@@ -12,7 +12,7 @@ export interface CollectionState {
   pageUrl?: string;
 }
 
-const initialState: CollectionState = {
+export const initialState: CollectionState = {
   url: null,
   data: null,
   isFetching: false,

--- a/packages/opds-web-client/src/reducers/collection.ts
+++ b/packages/opds-web-client/src/reducers/collection.ts
@@ -4,7 +4,7 @@ import ActionCreator from "../actions";
 
 export interface CollectionState {
   url: string;
-  data: CollectionData;
+  data?: CollectionData;
   isFetching: boolean;
   isFetchingPage: boolean;
   error: FetchErrorData;

--- a/packages/opds-web-client/src/state.ts
+++ b/packages/opds-web-client/src/state.ts
@@ -18,8 +18,8 @@ export interface State {
     package, but it's available for other apps if they need to build the state
     for server-side rendering. */
 export default function buildInitialState(
-  collectionUrl: string,
-  bookUrl: string
+  collectionUrl?: string,
+  bookUrl?: string
 ): Promise<State> {
   const store = buildStore(undefined, []);
   const fetchCollectionAndBook = createFetchCollectionAndBook(store.dispatch);

--- a/packages/opds-web-client/src/utils/__tests__/file-test.ts
+++ b/packages/opds-web-client/src/utils/__tests__/file-test.ts
@@ -1,0 +1,52 @@
+import { generateFilename } from "./../file";
+import { expect } from "chai";
+
+describe("file utils", () => {
+  /**
+   * All lowercase
+   * Appends the extension
+   * Replaces characters
+   * handles empty extension
+   * handles empty filename
+   */
+
+  describe("generateFilename", () => {
+    const str = "MyFileNameWoopee";
+    const ext = ".pdf";
+
+    it("appends extension", () => {
+      const result = generateFilename(str, ext);
+      expect(result).to.equal("myfilenamewoopee.pdf");
+    });
+
+    it("converts to lowercase", () => {
+      const result = generateFilename(str, ext);
+      expect(result).to.equal("myfilenamewoopee.pdf");
+    });
+
+    it("replaces non a-z 0-9 chars with -", () => {
+      const result = generateFilename(
+        "this!file*is%gonna$fail#unless:these@are^all)removed",
+        ".pdf"
+      );
+      expect(result).to.equal(
+        "this-file-is-gonna-fail-unless-these-are-all-removed.pdf"
+      );
+    });
+
+    it("removes trailing and leading -s ", () => {
+      const result = generateFilename("-test-", ".pdf");
+      expect(result).to.equal("test.pdf");
+    });
+
+    it("handles empty filename", () => {
+      const result = generateFilename("", ".ext");
+      expect(result).to.equal(".ext");
+    });
+
+    it("handles empty extension", () => {
+      const result = generateFilename("test", "");
+      expect(result).to.equal("test");
+    });
+  });
+});

--- a/packages/opds-web-client/src/utils/file.ts
+++ b/packages/opds-web-client/src/utils/file.ts
@@ -1,0 +1,27 @@
+export const typeMap = {
+  "application/epub+zip": {
+    extension: ".epub",
+    name: "ePub"
+  },
+  "application/pdf": {
+    extension: ".pdf",
+    name: "PDF"
+  },
+  "application/vnd.adobe.adept+xml": {
+    extension: ".acsm",
+    name: "ACSM"
+  },
+  "application/x-mobipocket-ebook": {
+    extension: ".mobi",
+    name: "MOBI"
+  }
+};
+
+export const generateFilename = (str: string, extension: string) => {
+  return (
+    str
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/(^-|-$)/g, "") + extension
+  );
+};

--- a/packages/opds-web-client/src/utils/file.ts
+++ b/packages/opds-web-client/src/utils/file.ts
@@ -1,7 +1,16 @@
-export const typeMap = {
+import { OpenAccessLinkType } from "./../interfaces";
+
+type TypeMap = {
+  [key in OpenAccessLinkType]: {
+    extension: string;
+    name: string;
+  };
+};
+
+export const typeMap: TypeMap = {
   "application/epub+zip": {
     extension: ".epub",
-    name: "ePub"
+    name: "EPUB"
   },
   "application/pdf": {
     extension: ".pdf",
@@ -14,6 +23,10 @@ export const typeMap = {
   "application/x-mobipocket-ebook": {
     extension: ".mobi",
     name: "MOBI"
+  },
+  "application/x-mobi8-ebook": {
+    extension: ".azw3",
+    name: "Mobi8"
   }
 };
 


### PR DESCRIPTION
Hi all,

This PR provides some type fixes that I needed in order to work with the repo properly in circulation-patron-web. It does two other things as well:

1. I created a hook called `usePathFor` which is a simple wrapper around `React.useContext(PathForContext)`, providing additional null checks that are useful so that the context consumer doesn't have to check for undefined every time they want to use the context. 
2. I extracted a bit of the logic in `DownloadButton` so that I could import and reuse it in circulation-patron-web. 

Let me know if you have any questions