### PR TITLE
Converting DownloadButton to a functional component and using hooks for actions.

### DIFF
--- a/packages/opds-web-client/CHANGELOG.md
+++ b/packages/opds-web-client/CHANGELOG.md
@@ -1,24 +1,31 @@
 ## Changelog
 
+### v0.3.4
+
+- Converted `Breadcrumbs.tsx` into a functional component.
+- Created custom hooks for to use with redux: `useTypedSelector`, `useThunkDispatch`, and `useActions`.
+- Refactored `DownloadButton.tsx` to use the hooks to call actions instead of having the `fulfillbook` and `indirectFulfillBook` functions be passed down as props from the root application component.
+
+
 ### v0.3.3
 
-- created a hook called `usePathFor` to consume `PathFor` context
-- extracted `DownloadButton` logic for use in circulation-patron-web
-- made many properties optional because they were already effectively optional, only this
-  repo didn't have `strictNullChecks` turned on, while circulation-patron-web now does
-- make `OpenAccessLinksType` string literal type for better checking and autofill
+- Created a hook called `usePathFor` to consume `PathFor` context.
+- Etracted `DownloadButton` logic for use in circulation-patron-web.
+- Made many properties optional because they were already effectively optional, only this
+  repo didn't have `strictNullChecks` turned on, while circulation-patron-web now does.
+- Made `OpenAccessLinksType` string literal type for better checking and autofill.
 
 ### v0.3.2
 
-- Pass the redux store down the tree via context
-- Extracted PathForContext from the Root, which provides context via both legacy and new context APIs
+- Pass the redux store down the tree via context.
+- Extracted PathForContext from the Root, which provides context via both legacy and new context APIs.
 - Created a RouterContext component which can be used by any application to pass a `router` context down the tree. See `circulation-patron-web` as an example.
 
 ### v0.3.1
 
-- added "prettier" code formatter and a git hook to run prettier before each commit
-- Updated tslint config to include prettier so that formatting is no longer a lint concern
-- ran prettier on all files, so many small file changes.
+- Added "prettier" code formatter and a git hook to run prettier before each commit.
+- Updated tslint config to include prettier so that formatting is no longer a lint concern.
+- Ran prettier on all files, so many small file changes.
 
 ### v0.3.0
 

--- a/packages/opds-web-client/package-lock.json
+++ b/packages/opds-web-client/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "opds-web-client",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/opds-web-client/package.json
+++ b/packages/opds-web-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opds-web-client",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "OPDS web client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/packages/opds-web-client/src/app.tsx
+++ b/packages/opds-web-client/src/app.tsx
@@ -8,6 +8,7 @@ import { PathFor } from "./interfaces";
 import AuthPlugin from "./AuthPlugin";
 import "./stylesheets/app.scss";
 import PathForProvider from "./components/context/PathForContext";
+import { ActionsProvider } from "./components/context/ActionsContext";
 
 const OPDSCatalogRouterHandler = config => {
   interface OPDSCatalogParams {
@@ -31,7 +32,9 @@ const OPDSCatalogRouterHandler = config => {
       };
       return (
         <PathForProvider pathFor={config.pathFor}>
-          <OPDSCatalog {...mergedProps} />
+          <ActionsProvider>
+            <OPDSCatalog {...mergedProps} />
+          </ActionsProvider>
         </PathForProvider>
       );
     }

--- a/packages/opds-web-client/src/components/Book.tsx
+++ b/packages/opds-web-client/src/components/Book.tsx
@@ -11,8 +11,6 @@ export interface BookProps {
   book: BookData;
   collectionUrl?: string;
   updateBook: (url: string) => Promise<BookData>;
-  fulfillBook: (url: string) => Promise<Blob>;
-  indirectFulfillBook: (url: string, type: string) => Promise<string>;
   isSignedIn?: boolean;
   epubReaderUrlTemplate?: (epubUrl: string) => string;
 }
@@ -202,8 +200,6 @@ export default class Book<P extends BookProps> extends React.Component<P, {}> {
           return (
             <DownloadButton
               key={`${link.url}-${index}`}
-              fulfill={this.props.fulfillBook}
-              indirectFulfill={this.props.indirectFulfillBook}
               url={link.url}
               mimeType={link.type}
               title={this.props.book.title}
@@ -228,8 +224,6 @@ export default class Book<P extends BookProps> extends React.Component<P, {}> {
           return (
             <DownloadButton
               key={`${link.url}-${index}`}
-              fulfill={this.props.fulfillBook}
-              indirectFulfill={this.props.indirectFulfillBook}
               url={link.url}
               mimeType={link.type}
               title={this.props.book.title}

--- a/packages/opds-web-client/src/components/Breadcrumbs.tsx
+++ b/packages/opds-web-client/src/components/Breadcrumbs.tsx
@@ -11,36 +11,37 @@ export interface ComputeBreadcrumbs {
   (collection: CollectionData, history: LinkData[]): LinkData[];
 }
 
-/** Shows a list of breadcrumbs links above a collection. */
-export default class Breadcrumbs extends React.Component<BreadcrumbsProps, {}> {
-  public static defaultProps: Partial<BreadcrumbsProps> = {
-    currentLink: false
-  };
-  render(): JSX.Element {
-    return (
-      <nav aria-label="breadcrumbs" role="navigation">
-        <ol className="breadcrumbs">
-          {this.props.links &&
-            this.props.links.map((link, i) => (
-              <li key={link.url} className="breadcrumb">
-                {i === this.props.links.length - 1 &&
-                !this.props.currentLink ? (
-                  <span>{link.text}</span>
-                ) : (
-                  <CatalogLink collectionUrl={link.url} bookUrl={null}>
-                    {link.text}
-                  </CatalogLink>
-                )}
-              </li>
-            ))}
-        </ol>
-      </nav>
-    );
-  }
-}
+/**
+ * Shows a list of breadcrumbs links above a collection.
+ **/
+const Breadcrumbs: React.FC<BreadcrumbsProps> = ({ links, currentLink }) => (
+  <nav aria-label="breadcrumbs" role="navigation">
+    <ol className="breadcrumbs">
+      {links &&
+        links.map((link, i) => (
+          <li key={link.url} className="breadcrumb">
+            {i === links.length - 1 && !currentLink ? (
+              <span>{link.text}</span>
+            ) : (
+              <CatalogLink collectionUrl={link.url} bookUrl={null}>
+                {link.text}
+              </CatalogLink>
+            )}
+          </li>
+        ))}
+    </ol>
+  </nav>
+);
+Breadcrumbs.defaultProps = {
+  currentLink: false
+};
 
-/** Computes breadcrumbs based on the browser history, with the current collection as the
-    final element. */
+export default Breadcrumbs;
+
+/**
+ * Computes breadcrumbs based on the browser history, with the current
+ * collection as the final element.
+ **/
 export function defaultComputeBreadcrumbs(
   collection: CollectionData,
   history: LinkData[]
@@ -57,9 +58,12 @@ export function defaultComputeBreadcrumbs(
   return links;
 }
 
-/** Computes breadcrumbs assuming that the OPDS feed is hierarchical - uses the catalog root
-    link, the parent of the current collection if it's not the root, and the current collection.
-    The OPDS spec doesn't require a hierarchy, so this may not make sense for some feeds. */
+/**
+ * Computes breadcrumbs assuming that the OPDS feed is hierarchical - uses
+ * the catalog root link, the parent of the current collection if it's not
+ * the root, and the current collection. The OPDS spec doesn't require a
+ * hierarchy, so this may not make sense for some feeds.
+ * */
 export function hierarchyComputeBreadcrumbs(
   collection: CollectionData,
   history: LinkData[],

--- a/packages/opds-web-client/src/components/Breadcrumbs.tsx
+++ b/packages/opds-web-client/src/components/Breadcrumbs.tsx
@@ -14,7 +14,10 @@ export interface ComputeBreadcrumbs {
 /**
  * Shows a list of breadcrumbs links above a collection.
  **/
-const Breadcrumbs: React.FC<BreadcrumbsProps> = ({ links, currentLink }) => (
+const Breadcrumbs: React.FC<BreadcrumbsProps> = ({
+  links,
+  currentLink = false
+}) => (
   <nav aria-label="breadcrumbs" role="navigation">
     <ol className="breadcrumbs">
       {links &&
@@ -32,9 +35,6 @@ const Breadcrumbs: React.FC<BreadcrumbsProps> = ({ links, currentLink }) => (
     </ol>
   </nav>
 );
-Breadcrumbs.defaultProps = {
-  currentLink: false
-};
 
 export default Breadcrumbs;
 

--- a/packages/opds-web-client/src/components/Collection.tsx
+++ b/packages/opds-web-client/src/components/Collection.tsx
@@ -93,8 +93,6 @@ export default class Collection extends React.Component<CollectionProps, {}> {
                 url={this.props.collection.url}
                 lanes={this.props.collection.lanes}
                 updateBook={this.props.updateBook}
-                fulfillBook={this.props.fulfillBook}
-                indirectFulfillBook={this.props.indirectFulfillBook}
                 isSignedIn={this.props.isSignedIn}
                 epubReaderUrlTemplate={this.props.epubReaderUrlTemplate}
               />
@@ -111,8 +109,6 @@ export default class Collection extends React.Component<CollectionProps, {}> {
                       book={book}
                       collectionUrl={this.props.collection.url}
                       updateBook={this.props.updateBook}
-                      fulfillBook={this.props.fulfillBook}
-                      indirectFulfillBook={this.props.indirectFulfillBook}
                       isSignedIn={this.props.isSignedIn}
                       epubReaderUrlTemplate={this.props.epubReaderUrlTemplate}
                     />

--- a/packages/opds-web-client/src/components/DownloadButton.tsx
+++ b/packages/opds-web-client/src/components/DownloadButton.tsx
@@ -1,132 +1,99 @@
 import * as React from "react";
 import download from "./download";
+import { useActions } from "./context/ActionsContext";
 
 export interface DownloadButtonProps extends React.HTMLProps<{}> {
   url: string;
   mimeType: string;
   isPlainLink?: boolean;
-  fulfill?: (url: string) => Promise<Blob>;
-  indirectFulfill?: (url: string, type: string) => Promise<string>;
   title?: string;
   indirectType?: string;
 }
 
-/** Shows a button to fulfill and download a book or download it directly. */
-export default class DownloadButton extends React.Component<
-  DownloadButtonProps,
-  {}
-> {
-  constructor(props) {
-    super(props);
-    this.fulfill = this.fulfill.bind(this);
-  }
-
-  render() {
-    // Only get the props needed for the anchor or button element.
-    const {
-      ref,
-      url,
-      mimeType,
-      isPlainLink,
-      fulfill,
-      indirectFulfill,
-      indirectType,
-      title,
-      type,
-      ...props
-    } = this.props;
-
-    return (
-      <span>
-        {this.props.isPlainLink ? (
-          <a
-            className="btn btn-default download-button"
-            {...props}
-            href={this.props.url}
-            target="_blank"
-          >
-            {this.downloadLabel()}
-          </a>
-        ) : (
-          <button
-            className={
-              "btn btn-default download-button download-" +
-              this.fileExtension().slice(1) +
-              "-button"
-            }
-            {...props}
-            onClick={this.fulfill}
-          >
-            {this.downloadLabel()}
-          </button>
-        )}
-      </span>
-    );
-  }
-
-  fulfill() {
-    if (this.isIndirect()) {
-      return this.props
-        .indirectFulfill(this.props.url, this.props.indirectType)
-        .then(url => {
-          window.open(url, "_blank");
-        });
+const DownloadButton: React.FC<DownloadButtonProps> = props => {
+  const {
+    ref,
+    url,
+    mimeType,
+    isPlainLink,
+    indirectType,
+    title,
+    type,
+    ...elementProps
+  } = props;
+  const { actions, dispatch } = useActions();
+  const fulfill = () => {
+    let dispatchFn;
+    if (isIndirect()) {
+      dispatchFn = dispatch(actions.indirectFulfillBook(url, indirectType))
+        .then(url => window.open(url, "_blank"));
     } else {
-      return this.props.fulfill(this.props.url).then(blob => {
-        download(
-          blob,
-          this.generateFilename(this.props.title),
-          // TODO: use mimeType variable once we fix the link type in our OPDS entries
-          this.mimeType()
-        );
-      });
+      dispatchFn = dispatch(actions.fulfillBook(url))
+        .then(blob => download(blob, generateFilename(title), mimeTypeFn()));
+        // TODO: use mimeType variable once we fix the link type in our
+        // OPDS entries
     }
-  }
-
-  isIndirect() {
-    return (
-      this.props.indirectType &&
-      this.props.mimeType ===
-        "application/atom+xml;type=entry;profile=opds-catalog"
-    );
-  }
-
-  generateFilename(str: string): string {
-    return (
-      str
-        .toLowerCase()
-        .replace(/[^a-z0-9]+/g, "-")
-        .replace(/(^-|-$)/g, "") + this.fileExtension()
-    );
-  }
-
-  mimeType() {
-    return this.props.mimeType === "vnd.adobe/adept+xml"
+    return dispatchFn;
+  };
+  const isIndirect = () => (
+    indirectType &&
+    mimeType === "application/atom+xml;type=entry;profile=opds-catalog"
+  );
+  const generateFilename = (str: string): string => (
+    str
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/(^-|-$)/g, "") + fileExtension()
+  );
+  const mimeTypeFn = () => (
+    mimeType === "vnd.adobe/adept+xml"
       ? "application/vnd.adobe.adept+xml"
-      : this.props.mimeType;
-  }
-
-  fileExtension() {
-    return (
-      {
-        "application/epub+zip": ".epub",
-        "application/pdf": ".pdf",
-        "application/vnd.adobe.adept+xml": ".acsm",
-        "application/x-mobipocket-ebook": ".mobi"
-      }[this.mimeType()] || ""
-    );
-  }
-
-  downloadLabel() {
+      : mimeType
+  );
+  const fileExtension = () => (
+    {
+      "application/epub+zip": ".epub",
+      "application/pdf": ".pdf",
+      "application/vnd.adobe.adept+xml": ".acsm",
+      "application/x-mobipocket-ebook": ".mobi"
+    }[mimeTypeFn()] || ""
+  );
+  const downloadLabel = () => {
     if (
-      this.props.indirectType ===
+      indirectType ===
       "text/html;profile=http://librarysimplified.org/terms/profiles/streaming-media"
     ) {
       return "Read Online";
     }
-    let type = this.fileExtension()
+    let type = fileExtension()
       .replace(".", "")
       .toUpperCase();
-    return "Download" + (type ? " " + type : "");
+    return `Download${type ? " " + type : ""}`;
   }
-}
+  let downloadProps = {
+    className: "btn btn-default download-button",
+    ...elementProps
+  }
+  if (isPlainLink) {
+    downloadProps["href"] = url;
+    downloadProps["target"] = "_blank";
+  } else {
+    downloadProps["onClick"] = fulfill;
+    downloadProps["className"] = downloadProps["className"] +
+      ` download-${fileExtension().slice(1)}-button`;
+  }
+
+  return (
+    <span>
+      {
+        React.createElement(
+          isPlainLink ? "a" : "button",
+          downloadProps,
+          downloadLabel()
+        )
+      }
+    </span>
+  );
+};
+
+export default DownloadButton;

--- a/packages/opds-web-client/src/components/DownloadButton.tsx
+++ b/packages/opds-web-client/src/components/DownloadButton.tsx
@@ -24,40 +24,42 @@ const DownloadButton: React.FC<DownloadButtonProps> = props => {
   const { actions, dispatch } = useActions();
   const fulfill = () => {
     let dispatchFn;
+    let action;
     if (isIndirect()) {
-      dispatchFn = dispatch(actions.indirectFulfillBook(url, indirectType))
-        .then(url => window.open(url, "_blank"));
+      action = actions.indirectFulfillBook(url, indirectType);
+      dispatchFn = dispatch(action).then(url => {
+        window.open(url, "_blank");
+        console.log("called window", window.open);
+      });
     } else {
-      dispatchFn = dispatch(actions.fulfillBook(url))
-        .then(blob => download(blob, generateFilename(title), mimeTypeFn()));
-        // TODO: use mimeType variable once we fix the link type in our
-        // OPDS entries
+      // TODO: use mimeType variable once we fix the link type in our
+      // OPDS entries
+      action = actions.fulfillBook(url);
+      dispatchFn = dispatch(action).then(blob => {
+        download(blob, generateFilename(title), mimeTypeFn());
+      });
     }
     return dispatchFn;
   };
-  const isIndirect = () => (
+  const isIndirect = () =>
     indirectType &&
-    mimeType === "application/atom+xml;type=entry;profile=opds-catalog"
-  );
-  const generateFilename = (str: string): string => (
+    mimeType === "application/atom+xml;type=entry;profile=opds-catalog";
+  const generateFilename = (str: string): string =>
     str
       .toLowerCase()
       .replace(/[^a-z0-9]+/g, "-")
-      .replace(/(^-|-$)/g, "") + fileExtension()
-  );
-  const mimeTypeFn = () => (
+      .replace(/(^-|-$)/g, "") + fileExtension();
+  const mimeTypeFn = () =>
     mimeType === "vnd.adobe/adept+xml"
       ? "application/vnd.adobe.adept+xml"
-      : mimeType
-  );
-  const fileExtension = () => (
-    {
+      : mimeType;
+  const fileExtension = () =>
+    ({
       "application/epub+zip": ".epub",
       "application/pdf": ".pdf",
       "application/vnd.adobe.adept+xml": ".acsm",
       "application/x-mobipocket-ebook": ".mobi"
-    }[mimeTypeFn()] || ""
-  );
+    }[mimeTypeFn()] || "");
   const downloadLabel = () => {
     if (
       indirectType ===
@@ -69,29 +71,28 @@ const DownloadButton: React.FC<DownloadButtonProps> = props => {
       .replace(".", "")
       .toUpperCase();
     return `Download${type ? " " + type : ""}`;
-  }
+  };
   let downloadProps = {
     className: "btn btn-default download-button",
     ...elementProps
-  }
+  };
   if (isPlainLink) {
     downloadProps["href"] = url;
     downloadProps["target"] = "_blank";
   } else {
     downloadProps["onClick"] = fulfill;
-    downloadProps["className"] = downloadProps["className"] +
-      ` download-${fileExtension().slice(1)}-button`;
+    downloadProps["className"] =
+      `${downloadProps["className"]} ` +
+      `download-${fileExtension().slice(1)}-button`;
   }
 
   return (
     <span>
-      {
-        React.createElement(
-          isPlainLink ? "a" : "button",
-          downloadProps,
-          downloadLabel()
-        )
-      }
+      {React.createElement(
+        isPlainLink ? "a" : "button",
+        downloadProps,
+        downloadLabel()
+      )}
     </span>
   );
 };

--- a/packages/opds-web-client/src/components/DownloadButton.tsx
+++ b/packages/opds-web-client/src/components/DownloadButton.tsx
@@ -29,7 +29,6 @@ const DownloadButton: React.FC<DownloadButtonProps> = props => {
       action = actions.indirectFulfillBook(url, indirectType);
       dispatchFn = dispatch(action).then(url => {
         window.open(url, "_blank");
-        console.log("called window", window.open);
       });
     } else {
       // TODO: use mimeType variable once we fix the link type in our

--- a/packages/opds-web-client/src/components/DownloadButton.tsx
+++ b/packages/opds-web-client/src/components/DownloadButton.tsx
@@ -23,36 +23,38 @@ const DownloadButton: React.FC<DownloadButtonProps> = props => {
     ...elementProps
   } = props;
   const { actions, dispatch } = useActions();
+  const mimeTypeValue =
+    mimeType === "vnd.adobe/adept+xml"
+      ? "application/vnd.adobe.adept+xml"
+      : mimeType;
   const fulfill = () => {
-    let dispatchFn;
     let action;
-    if (isIndirect()) {
+    if (isIndirect) {
       action = actions.indirectFulfillBook(url, indirectType);
-      dispatchFn = dispatch(action).then(url => {
+      return dispatch(action).then(url => {
         window.open(url, "_blank");
       });
     } else {
       // TODO: use mimeType variable once we fix the link type in our
       // OPDS entries
       action = actions.fulfillBook(url);
-      dispatchFn = dispatch(action).then(blob => {
-        download(blob, generateFilename(title, fileExtension()), mimeTypeFn());
+      return dispatch(action).then(blob => {
+        download(
+          blob,
+          generateFilename(title, fileExtension(mimeTypeValue)),
+          mimeTypeValue
+        );
       });
     }
-    return dispatchFn;
   };
-  const isIndirect = () =>
+  const isIndirect =
     indirectType &&
     mimeType === "application/atom+xml;type=entry;profile=opds-catalog";
-  const mimeTypeFn = () =>
-    mimeType === "vnd.adobe/adept+xml"
-      ? "application/vnd.adobe.adept+xml"
-      : mimeType;
-  const fileExtension = () =>
+  const fileExtension = (mimeTypeValue: string) =>
     // this ?? syntax is similar to x || y, except that it will only
     // fall back if the predicate is undefined or null, not if it
     // is falsy (false, 0, etc).
-    typeMap[mimeTypeFn()]?.extension ?? "";
+    typeMap[mimeTypeValue]?.extension ?? "";
   const downloadLabel = () => {
     if (
       indirectType ===
@@ -60,29 +62,29 @@ const DownloadButton: React.FC<DownloadButtonProps> = props => {
     ) {
       return "Read Online";
     }
-    let type = typeMap[mimeTypeFn()]?.name;
+    let type = typeMap[mimeTypeValue]?.name;
     return `Download${type ? " " + type : ""}`;
   };
-  let downloadProps = {
-    className: "btn btn-default download-button",
-    ...elementProps
-  };
-  if (isPlainLink) {
-    downloadProps["href"] = url;
-    downloadProps["target"] = "_blank";
-  } else {
-    downloadProps["onClick"] = fulfill;
-    downloadProps["className"] =
-      `${downloadProps["className"]} ` +
-      `download-${fileExtension().slice(1)}-button`;
-  }
+  const baseClassName = "btn btn-default download-button";
+  const buttonClassName = `${baseClassName} download-${fileExtension(
+    mimeTypeValue
+  ).slice(1)}-button`;
 
   return (
     <span>
-      {React.createElement(
-        isPlainLink ? "a" : "button",
-        downloadProps,
-        downloadLabel()
+      {isPlainLink ? (
+        <a
+          href={url}
+          target="_blank"
+          {...elementProps}
+          className={baseClassName}
+        >
+          {downloadLabel()}
+        </a>
+      ) : (
+        <button onClick={fulfill} {...elementProps} className={buttonClassName}>
+          {downloadLabel()}
+        </button>
       )}
     </span>
   );

--- a/packages/opds-web-client/src/components/Lane.tsx
+++ b/packages/opds-web-client/src/components/Lane.tsx
@@ -3,16 +3,16 @@ import Book from "./Book";
 import CatalogLink from "./CatalogLink";
 import LaneMoreLink from "./LaneMoreLink";
 import { LaneData, BookData } from "../interfaces";
+import useTypedSelector from "../hooks/useTypedSelector";
+import { useActions } from "./context/ActionsContext";
 
 export interface LaneProps {
   lane: LaneData;
   collectionUrl?: string;
   hideMoreLink?: boolean;
   hiddenBookIds?: string[];
-  updateBook: (url: string) => Promise<BookData>;
-  fulfillBook: (url: string) => Promise<Blob>;
-  indirectFulfillBook: (url: string, type: string) => Promise<string>;
   isSignedIn?: boolean;
+  updateBook: (url: string) => Promise<BookData>;
   epubReaderUrlTemplate?: (epubUrl: string) => string;
 }
 
@@ -67,8 +67,6 @@ export default class Lane extends React.Component<LaneProps, LaneState> {
                   book={book}
                   collectionUrl={this.props.collectionUrl}
                   updateBook={this.props.updateBook}
-                  fulfillBook={this.props.fulfillBook}
-                  indirectFulfillBook={this.props.indirectFulfillBook}
                   isSignedIn={this.props.isSignedIn}
                   epubReaderUrlTemplate={this.props.epubReaderUrlTemplate}
                 />

--- a/packages/opds-web-client/src/components/Lane.tsx
+++ b/packages/opds-web-client/src/components/Lane.tsx
@@ -3,8 +3,6 @@ import Book from "./Book";
 import CatalogLink from "./CatalogLink";
 import LaneMoreLink from "./LaneMoreLink";
 import { LaneData, BookData } from "../interfaces";
-import useTypedSelector from "../hooks/useTypedSelector";
-import { useActions } from "./context/ActionsContext";
 
 export interface LaneProps {
   lane: LaneData;

--- a/packages/opds-web-client/src/components/Lanes.tsx
+++ b/packages/opds-web-client/src/components/Lanes.tsx
@@ -25,8 +25,6 @@ export interface LanesProps {
   hideMoreLinks?: boolean;
   isFetching?: boolean;
   updateBook: (url: string) => Promise<BookData>;
-  fulfillBook: (url: string) => Promise<Blob>;
-  indirectFulfillBook: (url: string, type: string) => Promise<string>;
   isSignedIn?: boolean;
   epubReaderUrlTemplate?: (epubUrl: string) => string;
 }
@@ -49,12 +47,10 @@ export class Lanes extends React.Component<LanesProps, {}> {
                 <li key={index}>
                   <Lane
                     lane={lane}
-                    collectionUrl={this.props.url}
                     hideMoreLink={this.props.hideMoreLinks}
+                    collectionUrl={this.props.url}
                     hiddenBookIds={this.props.hiddenBookIds}
                     updateBook={this.props.updateBook}
-                    fulfillBook={this.props.fulfillBook}
-                    indirectFulfillBook={this.props.indirectFulfillBook}
                     isSignedIn={this.props.isSignedIn}
                     epubReaderUrlTemplate={this.props.epubReaderUrlTemplate}
                   />

--- a/packages/opds-web-client/src/components/Root.tsx
+++ b/packages/opds-web-client/src/components/Root.tsx
@@ -136,13 +136,13 @@ export class Root extends React.Component<RootProps, RootState> {
       this.props.collectionData,
       this.props.history
     );
+    let showBreadcrumbs =
+      this.props.collectionData && breadcrumbsLinks.length > 0;
 
     let showCollection = this.props.collectionData && !this.props.bookData;
     let showBook = this.props.bookData;
     let showBookWrapper = this.props.bookUrl || this.props.bookData;
     let showUrlForm = !this.props.collectionUrl && !this.props.bookUrl;
-    let showBreadcrumbs =
-      this.props.collectionData && breadcrumbsLinks.length > 0;
     let showSearch =
       this.props.collectionData && this.props.collectionData.search;
     let showFooter = this.props.collectionData && Footer;
@@ -281,8 +281,6 @@ export class Root extends React.Component<RootProps, RootState> {
                           this.props.bookUrl
                         )}
                         updateBook={this.props.updateBook}
-                        fulfillBook={this.props.fulfillBook}
-                        indirectFulfillBook={this.props.indirectFulfillBook}
                         isSignedIn={this.props.isSignedIn}
                         epubReaderUrlTemplate={this.props.epubReaderUrlTemplate}
                       />
@@ -295,8 +293,6 @@ export class Root extends React.Component<RootProps, RootState> {
                           this.props.bookUrl
                         )}
                         updateBook={this.props.updateBook}
-                        fulfillBook={this.props.fulfillBook}
-                        indirectFulfillBook={this.props.indirectFulfillBook}
                         isSignedIn={this.props.isSignedIn}
                         epubReaderUrlTemplate={this.props.epubReaderUrlTemplate}
                       />

--- a/packages/opds-web-client/src/components/__tests__/Book-test.tsx
+++ b/packages/opds-web-client/src/components/__tests__/Book-test.tsx
@@ -5,6 +5,7 @@ import * as React from "react";
 import * as PropTypes from "prop-types";
 import { shallow, mount } from "enzyme";
 import { AudioHeadphoneIcon } from "@nypl/dgx-svg-icons";
+import { Provider } from "react-redux";
 
 import Book from "../Book";
 import { BookData } from "../../interfaces";
@@ -13,6 +14,9 @@ import BookCover from "../BookCover";
 import BorrowButton from "../BorrowButton";
 import DownloadButton from "../DownloadButton";
 import { mockRouterContext } from "../../__mocks__/routing";
+import { ActionsProvider } from "../context/ActionsContext";
+import ActionCreator from "../../actions";
+import buildStore from "../../store";
 
 let book: BookData = {
   id: "urn:librarysimplified.org/terms/id/3M%20ID/crrmnr9",
@@ -52,12 +56,7 @@ describe("Book", () => {
   });
 
   it("shows the book cover", () => {
-    let wrapper = shallow(
-      <Book
-        book={book}
-        updateBook={updateBook}
-      />
-    );
+    let wrapper = shallow(<Book book={book} updateBook={updateBook} />);
 
     let links = wrapper.find(CatalogLink);
     let cover = links
@@ -69,12 +68,7 @@ describe("Book", () => {
   });
 
   it("has language attribute matching the book's language", () => {
-    let wrapper = shallow(
-      <Book
-        book={book}
-        updateBook={updateBook}
-      />
-    );
+    let wrapper = shallow(<Book book={book} updateBook={updateBook} />);
 
     let bookElement = wrapper.find(".book");
     expect(bookElement.props().lang).to.equal("de");
@@ -82,12 +76,7 @@ describe("Book", () => {
 
   describe("getMedium function", () => {
     it("returns value with data or an empty string", () => {
-      let wrapper = shallow(
-        <Book
-          book={book}
-          updateBook={updateBook}
-        />
-      );
+      let wrapper = shallow(<Book book={book} updateBook={updateBook} />);
 
       let instance = wrapper.instance() as any;
       let getMedium = instance.getMedium;
@@ -108,12 +97,7 @@ describe("Book", () => {
     let getMediumSVG;
 
     beforeEach(() => {
-      wrapper = shallow(
-        <Book
-          book={book}
-          updateBook={updateBook}
-        />
-      );
+      wrapper = shallow(<Book book={book} updateBook={updateBook} />);
 
       instance = wrapper.instance() as any;
       getMediumSVG = instance.getMediumSVG;
@@ -142,12 +126,7 @@ describe("Book", () => {
 
   describe("compact info", () => {
     it("shows book info", () => {
-      let wrapper = shallow(
-        <Book
-          book={book}
-          updateBook={updateBook}
-        />
-      );
+      let wrapper = shallow(<Book book={book} updateBook={updateBook} />);
 
       let links = wrapper.find(CatalogLink);
       let bookInfo = links
@@ -166,12 +145,7 @@ describe("Book", () => {
         authors: [],
         contributors: ["contributor"]
       });
-      let wrapper = shallow(
-        <Book
-          book={bookCopy}
-          updateBook={updateBook}
-        />
-      );
+      let wrapper = shallow(<Book book={bookCopy} updateBook={updateBook} />);
 
       let links = wrapper.find(CatalogLink);
       let bookInfo = links
@@ -183,12 +157,7 @@ describe("Book", () => {
     });
 
     it("renders two icons and labels in the compact and expanded views", () => {
-      let wrapper = shallow(
-        <Book
-          book={book}
-          updateBook={updateBook}
-        />
-      );
+      let wrapper = shallow(<Book book={book} updateBook={updateBook} />);
 
       let itemIcon = wrapper.find(".item-icon");
       let svg = itemIcon.find(AudioHeadphoneIcon);
@@ -229,12 +198,7 @@ describe("Book", () => {
         authors: [],
         contributors: ["contributor"]
       });
-      wrapper = shallow(
-        <Book
-          book={bookCopy}
-          updateBook={updateBook}
-        />
-      );
+      wrapper = shallow(<Book book={bookCopy} updateBook={updateBook} />);
 
       let bookInfo = wrapper.find(".expanded-info");
       let authors = bookInfo.find(".authors");
@@ -256,12 +220,7 @@ describe("Book", () => {
       let bookCopy = Object.assign({}, book, {
         publisher: null
       });
-      wrapper = shallow(
-        <Book
-          book={bookCopy}
-          updateBook={stub()}
-        />
-      );
+      wrapper = shallow(<Book book={bookCopy} updateBook={stub()} />);
 
       let publisher = wrapper.find(".publisher");
       expect(publisher.length).to.equal(0);
@@ -279,12 +238,7 @@ describe("Book", () => {
 
     it("doesn't show categories when there aren't any", () => {
       let bookCopy = Object.assign({}, book, { categories: [] });
-      wrapper = shallow(
-        <Book
-          book={bookCopy}
-          updateBook={stub()}
-        />
-      );
+      wrapper = shallow(<Book book={bookCopy} updateBook={stub()} />);
 
       let categories = wrapper.find(".categories");
       expect(categories.length).to.equal(0);
@@ -297,16 +251,19 @@ describe("Book", () => {
 
     it("shows summary, in book's language, with html stripped out and more link", () => {
       let context = mockRouterContext();
+      let store = buildStore();
       wrapper = mount(
-        <Book
-          book={book}
-          updateBook={updateBook}
-        />,
+        <Provider store={store}>
+          <ActionsProvider>
+            <Book book={book} updateBook={updateBook} />
+          </ActionsProvider>
+        </Provider>,
         {
           context,
           childContextTypes: {
             router: PropTypes.object,
-            pathFor: PropTypes.func
+            pathFor: PropTypes.func,
+            actions: PropTypes.any
           }
         }
       );
@@ -347,12 +304,7 @@ describe("Book", () => {
         borrowUrl: "borrow url"
       });
       let updateBook = stub();
-      wrapper = shallow(
-        <Book
-          book={bookCopy}
-          updateBook={updateBook}
-        />
-      );
+      wrapper = shallow(<Book book={bookCopy} updateBook={updateBook} />);
 
       let button = wrapper.find(BorrowButton);
       expect(button.children().text()).to.equal("Borrow");
@@ -377,18 +329,10 @@ describe("Book", () => {
         openAccessLinks: [],
         fulfillmentLinks: [link]
       });
-      let fulfillBook = stub();
-      let indirectFulfillBook = stub();
       wrapper = shallow(
-        <Book
-          book={bookCopy}
-          updateBook={stub()}
-          isSignedIn={false}
-        />
+        <Book book={bookCopy} updateBook={stub()} isSignedIn={false} />
       );
       let button = wrapper.find(DownloadButton);
-      expect(button.props().fulfill).to.equal(fulfillBook);
-      expect(button.props().indirectFulfill).to.equal(indirectFulfillBook);
       expect(button.props().url).to.equal(link.url);
       expect(button.props().title).to.equal(bookCopy.title);
       expect(button.props().mimeType).to.equal(link.type);
@@ -404,12 +348,7 @@ describe("Book", () => {
         openAccessLinks: [],
         fulfillmentLinks: [link]
       });
-      wrapper = shallow(
-        <Book
-          book={bookCopy}
-          updateBook={stub()}
-        />
-      );
+      wrapper = shallow(<Book book={bookCopy} updateBook={stub()} />);
       let button = wrapper.find(BorrowButton);
       expect(button.props().children).to.equal("Borrowed");
       expect(button.props().disabled).to.equal(true);
@@ -420,12 +359,7 @@ describe("Book", () => {
         openAccessLinks: [],
         availability: { status: "reserved" }
       });
-      wrapper = shallow(
-        <Book
-          book={bookCopy}
-          updateBook={stub()}
-        />
-      );
+      wrapper = shallow(<Book book={bookCopy} updateBook={stub()} />);
       let button = wrapper.find("button");
       expect(button.text()).to.equal("Reserved");
       expect(button.props().className).to.contain("disabled");
@@ -436,12 +370,7 @@ describe("Book", () => {
         openAccessLinks: [],
         availability: { status: "ready" }
       });
-      wrapper = shallow(
-        <Book
-          book={bookCopy}
-          updateBook={stub()}
-        />
-      );
+      wrapper = shallow(<Book book={bookCopy} updateBook={stub()} />);
       let button = wrapper.find(BorrowButton);
       expect(button.length).to.equal(1);
       expect(button.html()).to.contain("Borrow");

--- a/packages/opds-web-client/src/components/__tests__/Book-test.tsx
+++ b/packages/opds-web-client/src/components/__tests__/Book-test.tsx
@@ -15,7 +15,6 @@ import BorrowButton from "../BorrowButton";
 import DownloadButton from "../DownloadButton";
 import { mockRouterContext } from "../../__mocks__/routing";
 import { ActionsProvider } from "../context/ActionsContext";
-import ActionCreator from "../../actions";
 import buildStore from "../../store";
 
 let book: BookData = {
@@ -44,14 +43,10 @@ let book: BookData = {
 
 describe("Book", () => {
   let updateBook;
-  let fulfillBook;
-  let indirectFulfillBook;
   let epubReaderUrlTemplate;
 
   beforeEach(() => {
     updateBook = stub();
-    fulfillBook = stub();
-    indirectFulfillBook = stub();
     epubReaderUrlTemplate = stub().returns("test reader url");
   });
 

--- a/packages/opds-web-client/src/components/__tests__/Book-test.tsx
+++ b/packages/opds-web-client/src/components/__tests__/Book-test.tsx
@@ -56,8 +56,6 @@ describe("Book", () => {
       <Book
         book={book}
         updateBook={updateBook}
-        fulfillBook={fulfillBook}
-        indirectFulfillBook={indirectFulfillBook}
       />
     );
 
@@ -75,8 +73,6 @@ describe("Book", () => {
       <Book
         book={book}
         updateBook={updateBook}
-        fulfillBook={fulfillBook}
-        indirectFulfillBook={indirectFulfillBook}
       />
     );
 
@@ -90,8 +86,6 @@ describe("Book", () => {
         <Book
           book={book}
           updateBook={updateBook}
-          fulfillBook={fulfillBook}
-          indirectFulfillBook={indirectFulfillBook}
         />
       );
 
@@ -118,8 +112,6 @@ describe("Book", () => {
         <Book
           book={book}
           updateBook={updateBook}
-          fulfillBook={fulfillBook}
-          indirectFulfillBook={indirectFulfillBook}
         />
       );
 
@@ -154,8 +146,6 @@ describe("Book", () => {
         <Book
           book={book}
           updateBook={updateBook}
-          fulfillBook={fulfillBook}
-          indirectFulfillBook={indirectFulfillBook}
         />
       );
 
@@ -180,8 +170,6 @@ describe("Book", () => {
         <Book
           book={bookCopy}
           updateBook={updateBook}
-          fulfillBook={fulfillBook}
-          indirectFulfillBook={indirectFulfillBook}
         />
       );
 
@@ -199,8 +187,6 @@ describe("Book", () => {
         <Book
           book={book}
           updateBook={updateBook}
-          fulfillBook={fulfillBook}
-          indirectFulfillBook={indirectFulfillBook}
         />
       );
 
@@ -224,8 +210,6 @@ describe("Book", () => {
         <Book
           book={book}
           updateBook={updateBook}
-          fulfillBook={fulfillBook}
-          indirectFulfillBook={indirectFulfillBook}
           epubReaderUrlTemplate={epubReaderUrlTemplate}
         />
       );
@@ -249,8 +233,6 @@ describe("Book", () => {
         <Book
           book={bookCopy}
           updateBook={updateBook}
-          fulfillBook={fulfillBook}
-          indirectFulfillBook={indirectFulfillBook}
         />
       );
 
@@ -278,8 +260,6 @@ describe("Book", () => {
         <Book
           book={bookCopy}
           updateBook={stub()}
-          fulfillBook={stub()}
-          indirectFulfillBook={stub()}
         />
       );
 
@@ -303,8 +283,6 @@ describe("Book", () => {
         <Book
           book={bookCopy}
           updateBook={stub()}
-          fulfillBook={stub()}
-          indirectFulfillBook={stub()}
         />
       );
 
@@ -323,8 +301,6 @@ describe("Book", () => {
         <Book
           book={book}
           updateBook={updateBook}
-          fulfillBook={stub()}
-          indirectFulfillBook={stub()}
         />,
         {
           context,
@@ -375,8 +351,6 @@ describe("Book", () => {
         <Book
           book={bookCopy}
           updateBook={updateBook}
-          fulfillBook={stub()}
-          indirectFulfillBook={stub()}
         />
       );
 
@@ -409,8 +383,6 @@ describe("Book", () => {
         <Book
           book={bookCopy}
           updateBook={stub()}
-          fulfillBook={fulfillBook}
-          indirectFulfillBook={indirectFulfillBook}
           isSignedIn={false}
         />
       );
@@ -436,8 +408,6 @@ describe("Book", () => {
         <Book
           book={bookCopy}
           updateBook={stub()}
-          fulfillBook={stub()}
-          indirectFulfillBook={stub()}
         />
       );
       let button = wrapper.find(BorrowButton);
@@ -454,8 +424,6 @@ describe("Book", () => {
         <Book
           book={bookCopy}
           updateBook={stub()}
-          fulfillBook={stub()}
-          indirectFulfillBook={stub()}
         />
       );
       let button = wrapper.find("button");
@@ -472,8 +440,6 @@ describe("Book", () => {
         <Book
           book={bookCopy}
           updateBook={stub()}
-          fulfillBook={stub()}
-          indirectFulfillBook={stub()}
         />
       );
       let button = wrapper.find(BorrowButton);

--- a/packages/opds-web-client/src/components/__tests__/BookDetails-test.tsx
+++ b/packages/opds-web-client/src/components/__tests__/BookDetails-test.tsx
@@ -46,8 +46,6 @@ describe("BookDetails", () => {
       <BookDetails
         book={book}
         updateBook={stub()}
-        fulfillBook={stub()}
-        indirectFulfillBook={stub()}
         epubReaderUrlTemplate={stub().returns("test reader url")}
       />
     );
@@ -106,8 +104,6 @@ describe("BookDetails", () => {
       <BookDetails
         book={bookCopy}
         updateBook={stub()}
-        fulfillBook={stub()}
-        indirectFulfillBook={stub()}
       />
     );
 
@@ -131,8 +127,6 @@ describe("BookDetails", () => {
       <BookDetails
         book={bookCopy}
         updateBook={stub()}
-        fulfillBook={stub()}
-        indirectFulfillBook={stub()}
       />
     );
 
@@ -188,8 +182,6 @@ describe("BookDetails", () => {
       <BookDetails
         book={bookCopy}
         updateBook={updateBook}
-        fulfillBook={stub()}
-        indirectFulfillBook={stub()}
       />
     );
 
@@ -222,8 +214,6 @@ describe("BookDetails", () => {
       <BookDetails
         book={bookCopy}
         updateBook={stub()}
-        fulfillBook={fulfillBook}
-        indirectFulfillBook={indirectFulfillBook}
         isSignedIn={false}
       />
     );
@@ -245,8 +235,6 @@ describe("BookDetails", () => {
       <BookDetails
         book={bookCopy}
         updateBook={stub()}
-        fulfillBook={stub()}
-        indirectFulfillBook={stub()}
       />
     );
     let button = wrapper.find("button");
@@ -269,8 +257,6 @@ describe("BookDetails", () => {
       <BookDetails
         book={bookCopy}
         updateBook={stub()}
-        fulfillBook={stub()}
-        indirectFulfillBook={stub()}
       />
     );
     let circulationInfo = wrapper.find(".circulation-info");
@@ -293,8 +279,6 @@ describe("BookDetails", () => {
       <BookDetails
         book={bookCopy}
         updateBook={stub()}
-        fulfillBook={stub()}
-        indirectFulfillBook={stub()}
       />
     );
     let circulationInfo = wrapper.find(".circulation-info");
@@ -320,8 +304,6 @@ describe("BookDetails", () => {
       <BookDetails
         book={bookCopy}
         updateBook={stub()}
-        fulfillBook={stub()}
-        indirectFulfillBook={stub()}
       />
     );
     let circulationInfo = wrapper.find(".circulation-info");
@@ -345,8 +327,6 @@ describe("BookDetails", () => {
       <BookDetails
         book={bookCopy}
         updateBook={stub()}
-        fulfillBook={stub()}
-        indirectFulfillBook={stub()}
       />
     );
     let circulationInfo = wrapper.find(".circulation-info");

--- a/packages/opds-web-client/src/components/__tests__/BookDetails-test.tsx
+++ b/packages/opds-web-client/src/components/__tests__/BookDetails-test.tsx
@@ -100,12 +100,7 @@ describe("BookDetails", () => {
     let bookCopy = Object.assign({}, book, {
       publisher: null
     });
-    wrapper = shallow(
-      <BookDetails
-        book={bookCopy}
-        updateBook={stub()}
-      />
-    );
+    wrapper = shallow(<BookDetails book={bookCopy} updateBook={stub()} />);
 
     let publisher = wrapper.find(".publisher");
     expect(publisher.length).to.equal(0);
@@ -123,12 +118,7 @@ describe("BookDetails", () => {
 
   it("doesn't show categories when there aren't any", () => {
     let bookCopy = Object.assign({}, book, { categories: [] });
-    wrapper = shallow(
-      <BookDetails
-        book={bookCopy}
-        updateBook={stub()}
-      />
-    );
+    wrapper = shallow(<BookDetails book={bookCopy} updateBook={stub()} />);
 
     let categories = wrapper.find(".categories");
     expect(categories.length).to.equal(0);
@@ -178,12 +168,7 @@ describe("BookDetails", () => {
       borrowUrl: "borrow url"
     });
     let updateBook = stub();
-    wrapper = shallow(
-      <BookDetails
-        book={bookCopy}
-        updateBook={updateBook}
-      />
-    );
+    wrapper = shallow(<BookDetails book={bookCopy} updateBook={updateBook} />);
 
     let button = wrapper.find(BorrowButton);
     expect(button.children().text()).to.equal("Borrow");
@@ -208,18 +193,10 @@ describe("BookDetails", () => {
       openAccessLinks: [],
       fulfillmentLinks: [link]
     });
-    let fulfillBook = stub();
-    let indirectFulfillBook = stub();
     wrapper = shallow(
-      <BookDetails
-        book={bookCopy}
-        updateBook={stub()}
-        isSignedIn={false}
-      />
+      <BookDetails book={bookCopy} updateBook={stub()} isSignedIn={false} />
     );
     let button = wrapper.find(DownloadButton);
-    expect(button.props().fulfill).to.equal(fulfillBook);
-    expect(button.props().indirectFulfill).to.equal(indirectFulfillBook);
     expect(button.props().url).to.equal(link.url);
     expect(button.props().title).to.equal(bookCopy.title);
     expect(button.props().mimeType).to.equal(link.type);
@@ -231,12 +208,7 @@ describe("BookDetails", () => {
       openAccessLinks: [],
       availability: { status: "reserved" }
     });
-    wrapper = shallow(
-      <BookDetails
-        book={bookCopy}
-        updateBook={stub()}
-      />
-    );
+    wrapper = shallow(<BookDetails book={bookCopy} updateBook={stub()} />);
     let button = wrapper.find("button");
     expect(button.text()).to.equal("Reserved");
     expect(button.props().className).to.contain("disabled");
@@ -253,12 +225,7 @@ describe("BookDetails", () => {
         total: 6
       }
     });
-    wrapper = shallow(
-      <BookDetails
-        book={bookCopy}
-        updateBook={stub()}
-      />
-    );
+    wrapper = shallow(<BookDetails book={bookCopy} updateBook={stub()} />);
     let circulationInfo = wrapper.find(".circulation-info");
     expect(circulationInfo.text()).to.contain("0 of 12 copies available");
     expect(circulationInfo.text()).to.contain("6 patrons in hold queue");
@@ -275,12 +242,7 @@ describe("BookDetails", () => {
         total: 6
       }
     });
-    wrapper = shallow(
-      <BookDetails
-        book={bookCopy}
-        updateBook={stub()}
-      />
-    );
+    wrapper = shallow(<BookDetails book={bookCopy} updateBook={stub()} />);
     let circulationInfo = wrapper.find(".circulation-info");
     expect(circulationInfo.text()).to.contain("5 of 12 copies available");
     expect(circulationInfo.text()).not.to.contain("6");
@@ -300,12 +262,7 @@ describe("BookDetails", () => {
       fulfillmentLinks: ["http://fulfill"],
       availability: { status: "available", until: tomorrow }
     });
-    wrapper = shallow(
-      <BookDetails
-        book={bookCopy}
-        updateBook={stub()}
-      />
-    );
+    wrapper = shallow(<BookDetails book={bookCopy} updateBook={stub()} />);
     let circulationInfo = wrapper.find(".circulation-info");
     expect(circulationInfo.text()).to.contain("on loan for a day");
   });
@@ -323,12 +280,7 @@ describe("BookDetails", () => {
         position: 3
       }
     });
-    wrapper = shallow(
-      <BookDetails
-        book={bookCopy}
-        updateBook={stub()}
-      />
-    );
+    wrapper = shallow(<BookDetails book={bookCopy} updateBook={stub()} />);
     let circulationInfo = wrapper.find(".circulation-info");
     expect(circulationInfo.text()).to.contain("0 of 12 copies available");
     expect(circulationInfo.text()).to.contain("6 patrons in hold queue");

--- a/packages/opds-web-client/src/components/__tests__/DownloadButton-test.tsx
+++ b/packages/opds-web-client/src/components/__tests__/DownloadButton-test.tsx
@@ -5,26 +5,46 @@ import * as download from "../download";
 const downloadMock = require("../../__mocks__/downloadjs");
 
 import * as React from "react";
-import { shallow } from "enzyme";
+import { mount, shallow } from "enzyme";
+import { Provider } from "react-redux";
 
 import DownloadButton from "../DownloadButton";
+import buildStore from "../../store";
+import { ActionsContext } from "../context/ActionsContext";
+import ActionCreator from "../../actions";
+import DataFetcher from "../../DataFetcher";
 
 describe("DownloadButton", () => {
   let wrapper;
   let fulfill;
   let indirectFulfill;
+  let acFStub;
+  let acIFStub;
   let style;
   let downloadStub;
+  let store = buildStore();
+  let fetcher = new DataFetcher();
+  let actions = new ActionCreator(fetcher);
+  let wrapperFn = component => (
+    <Provider store={store}>
+      <ActionsContext.Provider value={actions}>
+        {component}
+      </ActionsContext.Provider>
+    </Provider>
+  );
 
   beforeEach(() => {
     downloadStub = stub(download, "default").callsFake(downloadMock);
-
-    fulfill = stub().returns(new Promise((resolve, reject) => resolve("blob")));
-    indirectFulfill = stub().returns(
-      new Promise((resolve, reject) => resolve("web reader url"))
+    fulfill = stub().returns(
+      async () => new Promise((resolve, reject) => resolve("blob"))
     );
+    indirectFulfill = stub().returns(
+      async () => new Promise((resolve, reject) => resolve("web reader url"))
+    );
+    acFStub = stub(actions, "fulfillBook").callsFake(fulfill);
+    acIFStub = stub(actions, "indirectFulfillBook").callsFake(indirectFulfill);
     style = { border: "100px solid black" };
-    wrapper = shallow(
+    let downloadButton = wrapperFn(
       <DownloadButton
         style={style}
         url="download url"
@@ -32,9 +52,12 @@ describe("DownloadButton", () => {
         title="title"
       />
     );
+    wrapper = mount(downloadButton);
   });
 
   afterEach(() => {
+    acFStub.restore();
+    acIFStub.restore();
     downloadStub.restore();
   });
 
@@ -45,7 +68,16 @@ describe("DownloadButton", () => {
   });
 
   it("shows plain link if specified", () => {
-    wrapper.setProps({ isPlainLink: true });
+    let downloadButton = wrapperFn(
+      <DownloadButton
+        style={style}
+        url="download url"
+        mimeType="application/epub+zip"
+        title="title"
+        isPlainLink={true}
+      />
+    );
+    wrapper = mount(downloadButton);
     let link = wrapper.find("a");
     expect(link.props().style).to.deep.equal(style);
     expect(link.props().href).to.equal("download url");
@@ -59,71 +91,71 @@ describe("DownloadButton", () => {
     expect(fulfill.args[0][0]).to.equal("download url");
   });
 
-  it("downloads after fulfilling", done => {
+  it("downloads after fulfilling", async () => {
     let button = wrapper.find("button");
-    button
-      .props()
-      .onClick()
-      .then(() => {
-        expect(downloadMock.getBlob()).to.equal("blob");
-        expect(downloadMock.getFilename()).to.equal(
-          wrapper.instance().generateFilename("title")
-        );
-        expect(downloadMock.getMimeType()).to.equal(
-          wrapper.instance().mimeType()
-        );
-        done();
-      })
-      .catch(err => {
-        console.log(err);
-        throw err;
-      });
+    await button.props().onClick();
+    expect(downloadMock.getBlob()).to.equal("blob");
+    expect(downloadMock.getFilename()).to.equal("title.epub");
+    expect(downloadMock.getMimeType()).to.equal("application/epub+zip");
   });
 
-  it("fulfills OPDS-based indirect links", () => {
+  it("fulfills OPDS-based indirect links", async () => {
     let streamingType =
       "text/html;profile=http://librarysimplified.org/terms/profiles/streaming-media";
-    wrapper.setProps({
-      mimeType: "application/atom+xml;type=entry;profile=opds-catalog",
-      indirectType: streamingType
-    });
+    let downloadButton = wrapperFn(
+      <DownloadButton
+        style={style}
+        url="download url"
+        mimeType="application/atom+xml;type=entry;profile=opds-catalog"
+        indirectType={streamingType}
+        title="title"
+      />
+    );
+    wrapper = mount(downloadButton);
     let button = wrapper.find("button");
-    button.simulate("click");
+    await button.simulate("click");
     expect(indirectFulfill.callCount).to.equal(1);
     expect(indirectFulfill.args[0][0]).to.equal("download url");
     expect(indirectFulfill.args[0][1]).to.equal(streamingType);
   });
 
-  it("fulfills ACSM-based indirect links", () => {
-    wrapper.setProps({
-      mimeType: "vnd.adobe/adept+xml",
-      indirectType: "application/epub+zip"
-    });
+  it("fulfills ACSM-based indirect links", async () => {
+    let downloadButton = wrapperFn(
+      <DownloadButton
+        style={style}
+        url="download url"
+        mimeType="vnd.adobe/adept+xml"
+        indirectType="application/epub+zip"
+        title="title"
+      />
+    );
+    wrapper = mount(downloadButton);
     let button = wrapper.find("button");
-    button.simulate("click");
+    await button.simulate("click");
     expect(fulfill.callCount).to.equal(1);
     expect(fulfill.args[0][0]).to.equal("download url");
   });
 
-  it("opens indirect fulfillment link in new tab", done => {
-    wrapper.setProps({
-      mimeType: "application/atom+xml;type=entry;profile=opds-catalog",
-      indirectType: "some/type"
-    });
-    let windowOpenStub = stub(window, "open");
+  it("opens indirect fulfillment link in new tab", async () => {
+    let windowStub = stub(window, "open");
+    let downloadButton = wrapperFn(
+      <DownloadButton
+        style={style}
+        url="web reader url"
+        mimeType="application/atom+xml;type=entry;profile=opds-catalog"
+        indirectType="some/type"
+        title="title"
+      />
+    );
+    wrapper = mount(downloadButton);
     let button = wrapper.find("button");
-    button
-      .props()
-      .onClick()
-      .then(() => {
-        expect(windowOpenStub.callCount).to.equal(1);
-        expect(windowOpenStub.args[0][0]).to.equal("web reader url");
-        expect(windowOpenStub.args[0][1]).to.equal("_blank");
-        done();
-      })
-      .catch(err => {
-        console.log(err);
-        throw err;
-      });
+
+    await button.props().onClick();
+
+    expect(windowStub.callCount).to.equal(1);
+    expect(windowStub.args[0][0]).to.equal("web reader url");
+    expect(windowStub.args[0][1]).to.equal("_blank");
+
+    windowStub.restore();
   });
 });

--- a/packages/opds-web-client/src/components/__tests__/DownloadButton-test.tsx
+++ b/packages/opds-web-client/src/components/__tests__/DownloadButton-test.tsx
@@ -29,8 +29,6 @@ describe("DownloadButton", () => {
         style={style}
         url="download url"
         mimeType="application/epub+zip"
-        fulfill={fulfill}
-        indirectFulfill={indirectFulfill}
         title="title"
       />
     );

--- a/packages/opds-web-client/src/components/__tests__/DownloadButton-test.tsx
+++ b/packages/opds-web-client/src/components/__tests__/DownloadButton-test.tsx
@@ -5,7 +5,7 @@ import * as download from "../download";
 const downloadMock = require("../../__mocks__/downloadjs");
 
 import * as React from "react";
-import { mount, shallow } from "enzyme";
+import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { generateFilename, typeMap } from "../../utils/file";
 
@@ -19,14 +19,17 @@ describe("DownloadButton", () => {
   let wrapper;
   let fulfill;
   let indirectFulfill;
-  let acFStub;
-  let acIFStub;
+  let actionFulfillStub;
+  let acctionIndirectFulfillStub;
   let style;
   let downloadStub;
   let store = buildStore();
   let fetcher = new DataFetcher();
   let actions = new ActionCreator(fetcher);
-  let wrapperFn = component => (
+  /**
+   * Function to render a component wrapped in the Redux and Actions providers.
+   **/
+  const providerWrapper: React.FC<React.ReactNode> = component => (
     <Provider store={store}>
       <ActionsContext.Provider value={actions}>
         {component}
@@ -45,10 +48,12 @@ describe("DownloadButton", () => {
     indirectFulfill = stub().returns(
       async () => new Promise((resolve, reject) => resolve("web reader url"))
     );
-    acFStub = stub(actions, "fulfillBook").callsFake(fulfill);
-    acIFStub = stub(actions, "indirectFulfillBook").callsFake(indirectFulfill);
+    actionFulfillStub = stub(actions, "fulfillBook").callsFake(fulfill);
+    acctionIndirectFulfillStub = stub(actions, "indirectFulfillBook").callsFake(
+      indirectFulfill
+    );
     style = { border: "100px solid black" };
-    let downloadButton = wrapperFn(
+    let downloadButton = providerWrapper(
       <DownloadButton
         style={style}
         url="download url"
@@ -60,8 +65,8 @@ describe("DownloadButton", () => {
   });
 
   afterEach(() => {
-    acFStub.restore();
-    acIFStub.restore();
+    actionFulfillStub.restore();
+    acctionIndirectFulfillStub.restore();
     downloadStub.restore();
   });
 
@@ -72,7 +77,7 @@ describe("DownloadButton", () => {
   });
 
   it("shows plain link if specified", () => {
-    let downloadButton = wrapperFn(
+    let downloadButton = providerWrapper(
       <DownloadButton
         style={style}
         url="download url"
@@ -108,7 +113,7 @@ describe("DownloadButton", () => {
   it("fulfills OPDS-based indirect links", async () => {
     let streamingType =
       "text/html;profile=http://librarysimplified.org/terms/profiles/streaming-media";
-    let downloadButton = wrapperFn(
+    let downloadButton = providerWrapper(
       <DownloadButton
         style={style}
         url="download url"
@@ -126,7 +131,7 @@ describe("DownloadButton", () => {
   });
 
   it("fulfills ACSM-based indirect links", async () => {
-    let downloadButton = wrapperFn(
+    let downloadButton = providerWrapper(
       <DownloadButton
         style={style}
         url="download url"
@@ -144,7 +149,7 @@ describe("DownloadButton", () => {
 
   it("opens indirect fulfillment link in new tab", async () => {
     let windowStub = stub(window, "open");
-    let downloadButton = wrapperFn(
+    let downloadButton = providerWrapper(
       <DownloadButton
         style={style}
         url="web reader url"

--- a/packages/opds-web-client/src/components/__tests__/Lane-test.tsx
+++ b/packages/opds-web-client/src/components/__tests__/Lane-test.tsx
@@ -47,8 +47,6 @@ describe("Lane", () => {
           lane={laneData}
           collectionUrl="test collection"
           updateBook={updateBook}
-          fulfillBook={fulfillBook}
-          indirectFulfillBook={indirectFulfillBook}
         />
       );
     });
@@ -133,8 +131,6 @@ describe("Lane", () => {
           lane={laneData}
           collectionUrl="test collection"
           updateBook={updateBook}
-          fulfillBook={fulfillBook}
-          indirectFulfillBook={indirectFulfillBook}
         />,
         {
           context,

--- a/packages/opds-web-client/src/components/__tests__/Lanes-test.tsx
+++ b/packages/opds-web-client/src/components/__tests__/Lanes-test.tsx
@@ -28,8 +28,6 @@ describe("Lanes", () => {
         hideMoreLinks={true}
         hiddenBookIds={hiddenBookIds}
         updateBook={updateBook}
-        fulfillBook={fulfillBook}
-        indirectFulfillBook={indirectFulfillBook}
       />
     );
   });
@@ -58,8 +56,6 @@ describe("Lanes", () => {
         lanes={[]}
         fetchCollection={fetchCollection}
         updateBook={updateBook}
-        fulfillBook={fulfillBook}
-        indirectFulfillBook={indirectFulfillBook}
       />
     );
 
@@ -77,8 +73,6 @@ describe("Lanes", () => {
         clearCollection={clearCollection}
         fetchCollection={fetchCollection}
         updateBook={updateBook}
-        fulfillBook={fulfillBook}
-        indirectFulfillBook={indirectFulfillBook}
       />
     );
     expect(clearCollection.callCount).to.equal(0);
@@ -102,8 +96,6 @@ describe("Lanes", () => {
         lanes={[]}
         clearCollection={clearCollection}
         updateBook={updateBook}
-        fulfillBook={fulfillBook}
-        indirectFulfillBook={indirectFulfillBook}
       />
     );
     wrapper.instance().componentWillUnmount();

--- a/packages/opds-web-client/src/components/__tests__/Root-test.tsx
+++ b/packages/opds-web-client/src/components/__tests__/Root-test.tsx
@@ -399,8 +399,6 @@ describe("Root", () => {
     expect(bookWrapper.length).to.equal(1);
     expect(book.props().book).to.equal(loans[0]);
     expect(book.props().updateBook).to.equal(updateBook);
-    expect(book.props().fulfillBook).to.equal(fulfillBook);
-    expect(book.props().indirectFulfillBook).to.equal(indirectFulfillBook);
     expect(book.props().isSignedIn).to.equal(true);
     expect(book.props().epubReaderUrlTemplate).to.equal(epubReaderUrlTemplate);
   });

--- a/packages/opds-web-client/src/components/context/ActionsContext.tsx
+++ b/packages/opds-web-client/src/components/context/ActionsContext.tsx
@@ -4,6 +4,7 @@ import useThunkDispatch from "../../hooks/useThunkDispatch";
 import DataFetcher from "../../DataFetcher";
 import { adapter } from "../../OPDSDataAdapter";
 
+// The main context for this app's Actions.
 export const ActionsContext = React.createContext<ActionsCreator | undefined>(
   undefined
 );
@@ -19,6 +20,9 @@ export function ActionsProvider({ children }) {
   );
 }
 
+/**
+ * Custom hook used for getting access to the available Actions.
+ */
 export function useActions() {
   const context = React.useContext(ActionsContext);
   const dispatch = useThunkDispatch();

--- a/packages/opds-web-client/src/components/context/ActionsContext.tsx
+++ b/packages/opds-web-client/src/components/context/ActionsContext.tsx
@@ -1,0 +1,31 @@
+import * as React from "react";
+import ActionsCreator from "../../actions";
+import useThunkDispatch from "../../hooks/useThunkDispatch";
+import DataFetcher from "../../DataFetcher";
+import { adapter } from "../../OPDSDataAdapter";
+
+const ActionsContext = React.createContext<ActionsCreator | undefined>(
+  undefined
+);
+
+export function ActionsProvider({ children }) {
+  const fetcher = new DataFetcher({ adapter });
+  const actions = new ActionsCreator(fetcher);
+
+  return (
+    <ActionsContext.Provider value={actions}>
+      {children}
+    </ActionsContext.Provider>
+  );
+}
+
+export function useActions() {
+  const context = React.useContext(ActionsContext);
+  const dispatch = useThunkDispatch();
+  if (typeof context === "undefined") {
+    throw new Error("useActions must be used within a ActionsProvider");
+  }
+  return { actions: context, dispatch };
+}
+
+export default ActionsContext;

--- a/packages/opds-web-client/src/components/context/ActionsContext.tsx
+++ b/packages/opds-web-client/src/components/context/ActionsContext.tsx
@@ -4,7 +4,7 @@ import useThunkDispatch from "../../hooks/useThunkDispatch";
 import DataFetcher from "../../DataFetcher";
 import { adapter } from "../../OPDSDataAdapter";
 
-const ActionsContext = React.createContext<ActionsCreator | undefined>(
+export const ActionsContext = React.createContext<ActionsCreator | undefined>(
   undefined
 );
 

--- a/packages/opds-web-client/src/hooks/useThunkDispatch.tsx
+++ b/packages/opds-web-client/src/hooks/useThunkDispatch.tsx
@@ -1,0 +1,16 @@
+import { useDispatch } from "react-redux";
+import { ThunkDispatch } from "redux-thunk";
+import { State } from "../state";
+import { Action } from "redux";
+
+/**
+ * Custom hook to use react-redux dispatch typed properly for redux thunk
+ *  - note that actions are currently typed as any, as they are not strongly
+ * typed in OPDS-web-client
+ */
+export type ReduxDispatch = ThunkDispatch<State, undefined, Action>;
+const useThunkDispatch = (): ReduxDispatch => {
+  return useDispatch<ReduxDispatch>();
+};
+
+export default useThunkDispatch;

--- a/packages/opds-web-client/src/hooks/useTypedSelector.tsx
+++ b/packages/opds-web-client/src/hooks/useTypedSelector.tsx
@@ -1,0 +1,6 @@
+import { TypedUseSelectorHook, useSelector } from "react-redux";
+import { State } from "../state";
+
+const useTypedSelector: TypedUseSelectorHook<State> = useSelector;
+
+export default useTypedSelector;

--- a/packages/opds-web-client/src/hooks/useTypedSelector.tsx
+++ b/packages/opds-web-client/src/hooks/useTypedSelector.tsx
@@ -1,6 +1,10 @@
 import { TypedUseSelectorHook, useSelector } from "react-redux";
 import { State } from "../state";
 
+/**
+ * This creates a type-safe hook based on Redux's useSelector to be
+ * able to easily get the needed data from the store.
+ */
 const useTypedSelector: TypedUseSelectorHook<State> = useSelector;
 
 export default useTypedSelector;


### PR DESCRIPTION
@kristojorg , can you review this and let me know what you think so far?

I set up some actions and context as you recommended. The idea was to try to remove functions props from the `Lane` component but then realized that it would work better if it was from the `DownloadButton` component. This was mostly to remove the`fulfillBook` and `indirectFulfillBook` action props from Lanes -> Lane -> Book.

It sort of seems like more boilerplate-ish code to just pull in the actions and get state from the store but maybe I'll like it more when I keep using it.

I get a lot of linter errors but not sure why or how to fix them. If you check https://travis-ci.com/NYPL-Simplified/opds-web-client/builds/146845160 you'll see what I mean.