### PR TITLE
Strict null checks

### DIFF
--- a/packages/opds-web-client/package-lock.json
+++ b/packages/opds-web-client/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "opds-web-client",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/opds-web-client/src/AuthPlugin.ts
+++ b/packages/opds-web-client/src/AuthPlugin.ts
@@ -12,7 +12,7 @@ interface AuthPlugin {
   lookForCredentials: () => {
     credentials?: AuthCredentials;
     error?: string;
-  } | void;
+  } | null;
   formComponent?: new (props: AuthFormProps<AuthMethod>) => React.Component<
     AuthFormProps<AuthMethod>,
     {}

--- a/packages/opds-web-client/src/AuthPlugin.ts
+++ b/packages/opds-web-client/src/AuthPlugin.ts
@@ -12,7 +12,7 @@ interface AuthPlugin {
   lookForCredentials: () => {
     credentials?: AuthCredentials;
     error?: string;
-  } | null;
+  } | null | void;
   formComponent?: new (props: AuthFormProps<AuthMethod>) => React.Component<
     AuthFormProps<AuthMethod>,
     {}

--- a/packages/opds-web-client/src/DataFetcher.ts
+++ b/packages/opds-web-client/src/DataFetcher.ts
@@ -6,7 +6,7 @@ const Cookie = require("js-cookie");
 require("isomorphic-fetch");
 
 export interface RequestError {
-  status: number;
+  status: number | null;
   response: string;
   url: string;
   headers?: any;
@@ -30,8 +30,8 @@ export interface DataFetcherConfig {
 /** Handles requests to OPDS servers. */
 export default class DataFetcher {
   public authKey: string;
-  private proxyUrl: string;
-  private adapter: (data: OPDSFeed | OPDSEntry, url: string) => any;
+  private proxyUrl?: string;
+  private adapter?: (data: OPDSFeed | OPDSEntry, url: string) => any;
 
   constructor(config: DataFetcherConfig = {}) {
     this.proxyUrl = config.proxyUrl;
@@ -68,7 +68,7 @@ export default class DataFetcher {
               parser
                 .parse(text)
                 .then((parsedData: OPDSFeed | OPDSEntry) => {
-                  resolve(this.adapter(parsedData, url));
+                  resolve(this.adapter?.(parsedData, url));
                 })
                 .catch(err => {
                   reject({
@@ -148,7 +148,7 @@ export default class DataFetcher {
     }
   }
 
-  getAuthCredentials(): AuthCredentials {
+  getAuthCredentials(): AuthCredentials | undefined {
     let credentials = Cookie.get(this.authKey);
     if (credentials) {
       return JSON.parse(credentials);

--- a/packages/opds-web-client/src/DataFetcher.ts
+++ b/packages/opds-web-client/src/DataFetcher.ts
@@ -142,7 +142,7 @@ export default class DataFetcher {
     return fetch(url, options);
   }
 
-  setAuthCredentials(credentials: AuthCredentials): void {
+  setAuthCredentials(credentials?: AuthCredentials): void {
     if (credentials) {
       Cookie.set(this.authKey, JSON.stringify(credentials));
     }

--- a/packages/opds-web-client/src/__tests__/OPDSDataAdaptor-test.ts
+++ b/packages/opds-web-client/src/__tests__/OPDSDataAdaptor-test.ts
@@ -102,13 +102,13 @@ describe("OPDSDataAdapter", () => {
     let book = collection.lanes[0].books[0];
     expect(book.id).to.equal(entry.id);
     expect(book.title).to.equal(entry.title);
-    expect(book.authors.length).to.equal(2);
-    expect(book.authors[0]).to.equal(entry.authors[0].name);
-    expect(book.authors[1]).to.equal(entry.authors[1].name);
-    expect(book.contributors.length).to.equal(1);
-    expect(book.contributors[0]).to.equal(entry.contributors[0].name);
-    expect(book.series.name).to.equal(entry.series.name);
-    expect(book.series.position).to.equal(entry.series.position);
+    expect(book.authors?.length).to.equal(2);
+    expect(book.authors?.[0]).to.equal(entry.authors[0].name);
+    expect(book.authors?.[1]).to.equal(entry.authors[1].name);
+    expect(book.contributors?.length).to.equal(1);
+    expect(book.contributors?.[0]).to.equal(entry.contributors[0].name);
+    expect(book.series?.name).to.equal(entry.series.name);
+    expect(book.series?.position).to.equal(entry.series.position);
     expect(book.subtitle).to.equal(entry.subtitle);
     expect(book.summary).to.equal(sanitizeHtml(entry.summary.content));
     expect(book.summary).to.contain(
@@ -116,18 +116,18 @@ describe("OPDSDataAdapter", () => {
     );
     expect(book.summary).not.to.contain("script");
     expect(book.summary).not.to.contain("danger");
-    expect(book.categories.length).to.equal(2);
+    expect(book.categories?.length).to.equal(2);
     expect(book.categories).to.contain("label");
     expect(book.categories).to.contain("label 2");
     expect(book.imageUrl).to.equal(thumbImageLink.href);
     expect(book.publisher).to.equal("Fake Publisher");
     expect(book.published).to.equal("June 8, 2014");
     expect(book.language).to.equal("en");
-    expect(book.openAccessLinks[0].url).to.equal(openAccessLink.href);
+    expect(book.openAccessLinks?.[0].url).to.equal(openAccessLink.href);
     expect(book.borrowUrl).to.equal(borrowLink.href);
-    expect(book.fulfillmentLinks[0].url).to.equal(fulfillmentLink.href);
-    expect(book.fulfillmentLinks[0].type).to.equal(fulfillmentLink.type);
-    expect(book.fulfillmentLinks[0].indirectType).to.equal(
+    expect(book.fulfillmentLinks?.[0].url).to.equal(fulfillmentLink.href);
+    expect(book.fulfillmentLinks?.[0].type).to.equal(fulfillmentLink.type);
+    expect(book.fulfillmentLinks?.[0].indirectType).to.equal(
       fulfillmentLink.indirectAcquisitions[0].type
     );
     expect(book.availability).to.equal(borrowLink.availability);
@@ -187,30 +187,30 @@ describe("OPDSDataAdapter", () => {
     });
 
     let collection = feedToCollection(acquisitionFeed, "");
-    expect(collection.facetGroups.length).to.equal(2);
+    expect(collection.facetGroups?.length).to.equal(2);
 
-    let groupA = collection.facetGroups[0];
-    expect(groupA.label).to.equal("group A");
-    expect(groupA.facets.length).to.equal(2);
+    let groupA = collection.facetGroups?.[0];
+    expect(groupA?.label).to.equal("group A");
+    expect(groupA?.facets.length).to.equal(2);
 
-    let groupB = collection.facetGroups[1];
-    expect(groupB.label).to.equal("group B");
-    expect(groupB.facets.length).to.equal(1);
+    let groupB = collection.facetGroups?.[1];
+    expect(groupB?.label).to.equal("group B");
+    expect(groupB?.facets.length).to.equal(1);
 
-    let facet1 = groupA.facets[0];
-    expect(facet1.label).to.equal("title 1");
-    expect(facet1.active).to.be.ok;
-    expect(facet1.href).to.equal("href1");
+    let facet1 = groupA?.facets[0];
+    expect(facet1?.label).to.equal("title 1");
+    expect(facet1?.active).to.be.ok;
+    expect(facet1?.href).to.equal("href1");
 
-    let facet2 = groupB.facets[0];
-    expect(facet2.label).to.equal("title 2");
-    expect(facet2.active).not.to.be.ok;
-    expect(facet2.href).to.equal("href2");
+    let facet2 = groupB?.facets[0];
+    expect(facet2?.label).to.equal("title 2");
+    expect(facet2?.active).not.to.be.ok;
+    expect(facet2?.href).to.equal("href2");
 
-    let facet3 = groupA.facets[1];
-    expect(facet3.label).to.equal("title 3");
-    expect(facet3.active).not.to.be.ok;
-    expect(facet3.href).to.equal("href3");
+    let facet3 = groupA?.facets[1];
+    expect(facet3?.label).to.equal("title 3");
+    expect(facet3?.active).not.to.be.ok;
+    expect(facet3?.href).to.equal("href3");
   });
 
   it("extracts search link", () => {
@@ -226,7 +226,7 @@ describe("OPDSDataAdapter", () => {
 
     let collection = feedToCollection(navigationFeed, "");
     expect(collection.search).to.be.ok;
-    expect(collection.search.url).to.equal(searchLink.href);
+    expect(collection.search?.url).to.equal(searchLink.href);
   });
 
   it("extracts next page url", () => {
@@ -279,9 +279,9 @@ describe("OPDSDataAdapter", () => {
     });
 
     let collection = feedToCollection(acquisitionFeed, "");
-    expect(collection.links.length).to.equal(2);
-    let urls = collection.links.map(link => link.url).sort();
-    let types = collection.links.map(link => link.type).sort();
+    expect(collection.links?.length).to.equal(2);
+    let urls = collection.links?.map(link => link.url).sort();
+    let types = collection.links?.map(link => link.type).sort();
     expect(urls).to.deep.equal(["about", "terms"]);
     expect(types).to.deep.equal(["about", "terms-of-service"]);
   });

--- a/packages/opds-web-client/src/__tests__/OpenSearchDescriptionParser-test.ts
+++ b/packages/opds-web-client/src/__tests__/OpenSearchDescriptionParser-test.ts
@@ -22,9 +22,9 @@ describe("OpenSearchDescriptionParser", () => {
         "http://example.com"
       )
       .then(result => {
-        expect(result.searchData.description).to.equal("d");
-        expect(result.searchData.shortName).to.equal("s");
-        expect(result.searchData.template("test")).to.equal(
+        expect(result.searchData?.description).to.equal("d");
+        expect(result.searchData?.shortName).to.equal("s");
+        expect(result.searchData?.template("test")).to.equal(
           "http://example.com/test"
         );
         done();
@@ -45,9 +45,9 @@ describe("OpenSearchDescriptionParser", () => {
         "http://example.com"
       )
       .then(result => {
-        expect(result.searchData.description).to.equal("d");
-        expect(result.searchData.shortName).to.equal("s");
-        expect(result.searchData.template("test")).to.equal(
+        expect(result.searchData?.description).to.equal("d");
+        expect(result.searchData?.shortName).to.equal("s");
+        expect(result.searchData?.template("test")).to.equal(
           "http://example.com/test"
         );
         done();

--- a/packages/opds-web-client/src/actions.ts
+++ b/packages/opds-web-client/src/actions.ts
@@ -110,7 +110,7 @@ export default class ActionCreator {
     };
   }
 
-  fetchJSON<T>(type: string, url?: string) {
+  fetchJSON<T>(type: string, url: string) {
     let err: RequestError;
     return (dispatch): Promise<T> => {
       return new Promise<T>((resolve, reject) => {
@@ -171,7 +171,7 @@ export default class ActionCreator {
     };
   }
 
-  fetchOPDS<T>(type: string, url?: string) {
+  fetchOPDS<T>(type: string, url: string) {
     return (dispatch): Promise<T> => {
       dispatch(this.request(type, url));
       return new Promise<T>((resolve, reject) => {
@@ -272,7 +272,7 @@ export default class ActionCreator {
         this.fetcher
           .fetchOPDSData(url)
           .then((book: BookData) => {
-            let link = book.fulfillmentLinks.find(link => link.type === type);
+            let link = book.fulfillmentLinks?.find(link => link.type === type);
 
             if (link) {
               dispatch(this.success(ActionCreator.FULFILL_BOOK));
@@ -303,7 +303,7 @@ export default class ActionCreator {
     providers: AuthProvider<AuthMethod>[],
     title: string,
     error?: string,
-    attemptedProvider?: string
+    attemptedProvider?: string | null
   ) {
     return {
       type: ActionCreator.SHOW_AUTH_FORM,

--- a/packages/opds-web-client/src/app.tsx
+++ b/packages/opds-web-client/src/app.tsx
@@ -23,7 +23,7 @@ const OPDSCatalogRouterHandler = config => {
     };
 
     render() {
-      let { collectionUrl, bookUrl } = this.props.params;
+      let { collectionUrl, bookUrl } = this.props.params ?? {};
       let mergedProps: RootProps = {
         ...config,
         collectionUrl,

--- a/packages/opds-web-client/src/authMiddleware.ts
+++ b/packages/opds-web-client/src/authMiddleware.ts
@@ -9,7 +9,7 @@ import { AuthCallback, AuthProvider, AuthMethod, PathFor } from "./interfaces";
     See Redux Middleware docs:
     http://redux.js.org/docs/advanced/Middleware.html */
 
-export default (authPlugins: AuthPlugin[], pathFor: PathFor) => {
+export default (authPlugins: AuthPlugin[], pathFor?: PathFor) => {
   return store => next => action => {
     let fetcher = new DataFetcher();
     let actions = new ActionCreator(fetcher);
@@ -84,7 +84,7 @@ export default (authPlugins: AuthPlugin[], pathFor: PathFor) => {
                   let oldBookUrl = store.getState().book.url;
                   let currentUrl = window.location.pathname;
                   let cancel;
-                  if (pathFor(oldCollectionUrl, oldBookUrl) === currentUrl) {
+                  if (pathFor?.(oldCollectionUrl, oldBookUrl) === currentUrl) {
                     cancel = () => {
                       next(actions.hideAuthForm());
                     };

--- a/packages/opds-web-client/src/components/AuthProviderSelectionForm.tsx
+++ b/packages/opds-web-client/src/components/AuthProviderSelectionForm.tsx
@@ -11,7 +11,7 @@ export interface AuthFormProps<T extends AuthMethod> {
   saveCredentials?: (credentials: AuthCredentials) => void;
   callback?: AuthCallback;
   cancel?: () => void;
-  error?: string;
+  error?: string | null;
   provider: AuthProvider<T>;
 }
 
@@ -21,13 +21,13 @@ export interface AuthButtonProps<T extends AuthMethod> {
 }
 
 export interface AuthProviderSelectionFormProps {
-  hide: () => void;
-  saveCredentials: (credentials: AuthCredentials) => void;
+  hide?: () => void;
+  saveCredentials?: (credentials: AuthCredentials) => void;
   callback?: AuthCallback;
   cancel: () => void;
   title?: string;
-  error?: string;
-  attemptedProvider?: string;
+  error?: string | null;
+  attemptedProvider?: string | null;
   providers?: AuthProvider<AuthMethod>[];
 }
 

--- a/packages/opds-web-client/src/components/AuthProviderSelectionForm.tsx
+++ b/packages/opds-web-client/src/components/AuthProviderSelectionForm.tsx
@@ -12,7 +12,7 @@ export interface AuthFormProps<T extends AuthMethod> {
   callback?: AuthCallback;
   cancel?: () => void;
   error?: string;
-  provider?: AuthProvider<T>;
+  provider: AuthProvider<T>;
 }
 
 export interface AuthButtonProps<T extends AuthMethod> {
@@ -32,7 +32,7 @@ export interface AuthProviderSelectionFormProps {
 }
 
 export interface AuthProviderSelectionFormState {
-  selectedProvider: AuthProvider<AuthMethod>;
+  selectedProvider: AuthProvider<AuthMethod> | null;
 }
 
 /** Shows buttons for each available authentication provider, or the form for
@@ -43,9 +43,9 @@ export default class AuthProviderSelectionForm extends React.Component<
 > {
   constructor(props) {
     super(props);
-    let selectedProvider = null;
+    let selectedProvider: AuthProvider<AuthMethod> | null = null;
     if (this.props.error && this.props.attemptedProvider) {
-      for (let provider of this.props.providers) {
+      for (let provider of this.props.providers ?? []) {
         if (this.props.attemptedProvider === provider.id) {
           selectedProvider = provider;
           break;
@@ -71,7 +71,7 @@ export default class AuthProviderSelectionForm extends React.Component<
           <h3 id="auth-form-title">
             {this.props.title ? this.props.title + " " : ""}Login
           </h3>
-          {this.state.selectedProvider && (
+          {this.state.selectedProvider && AuthForm && (
             <AuthForm
               hide={this.props.hide}
               saveCredentials={this.props.saveCredentials}

--- a/packages/opds-web-client/src/components/AuthProviderSelectionForm.tsx
+++ b/packages/opds-web-client/src/components/AuthProviderSelectionForm.tsx
@@ -9,8 +9,8 @@ import {
 export interface AuthFormProps<T extends AuthMethod> {
   hide?: () => void;
   saveCredentials?: (credentials: AuthCredentials) => void;
-  callback?: AuthCallback;
-  cancel?: () => void;
+  callback?: AuthCallback | null;
+  cancel?: (() => void) | null;
   error?: string | null;
   provider: AuthProvider<T>;
 }
@@ -23,12 +23,12 @@ export interface AuthButtonProps<T extends AuthMethod> {
 export interface AuthProviderSelectionFormProps {
   hide?: () => void;
   saveCredentials?: (credentials: AuthCredentials) => void;
-  callback?: AuthCallback;
-  cancel: () => void;
-  title?: string;
+  callback?: AuthCallback | null;
+  cancel: (() => void) | null;
+  title?: string | null;
   error?: string | null;
   attemptedProvider?: string | null;
-  providers?: AuthProvider<AuthMethod>[];
+  providers?: AuthProvider<AuthMethod>[] | null;
 }
 
 export interface AuthProviderSelectionFormState {
@@ -95,7 +95,10 @@ export default class AuthProviderSelectionForm extends React.Component<
                     </li>
                   ))}
                 </ul>
-                <button className="btn btn-default" onClick={this.props.cancel}>
+                <button
+                  className="btn btn-default"
+                  onClick={this.props.cancel ?? undefined}
+                >
                   Cancel
                 </button>
               </div>

--- a/packages/opds-web-client/src/components/BasicAuthButton.tsx
+++ b/packages/opds-web-client/src/components/BasicAuthButton.tsx
@@ -8,7 +8,7 @@ export default class BasicAuthButton extends React.Component<
   {}
 > {
   render() {
-    let label = this.props.provider.method.description
+    let label = this.props.provider?.method.description
       ? "Log in with " + this.props.provider.method.description
       : "Log in";
 

--- a/packages/opds-web-client/src/components/BasicAuthForm.tsx
+++ b/packages/opds-web-client/src/components/BasicAuthForm.tsx
@@ -4,7 +4,7 @@ import { AuthFormProps } from "./AuthProviderSelectionForm";
 
 export interface BasicAuthFormProps extends AuthFormProps<BasicAuthMethod> {}
 export interface BasicAuthFormState {
-  error: string;
+  error?: string | null;
 }
 
 /** Form for logging in with basic auth. */
@@ -62,11 +62,11 @@ export default class BasicAuthForm extends React.Component<
   }
 
   loginLabel() {
-    return this.props.provider.method.labels.login || "username";
+    return this.props.provider?.method.labels.login || "username";
   }
 
   passwordLabel() {
-    return this.props.provider.method.labels.password || "password";
+    return this.props.provider?.method.labels.password || "password";
   }
 
   /**
@@ -96,11 +96,11 @@ export default class BasicAuthForm extends React.Component<
         this.passwordRef.current && this.passwordRef.current.value;
       let credentials = this.generateCredentials(login, password);
 
-      this.props.saveCredentials({
-        provider: this.props.provider.id,
+      this.props.saveCredentials?.({
+        provider: this.props.provider?.id,
         credentials: credentials
       });
-      this.props.hide();
+      this.props.hide?.();
 
       if (this.props.callback) {
         this.props.callback();

--- a/packages/opds-web-client/src/components/Book.tsx
+++ b/packages/opds-web-client/src/components/Book.tsx
@@ -3,14 +3,14 @@ import CatalogLink from "./CatalogLink";
 import BookCover from "./BookCover";
 import BorrowButton from "./BorrowButton";
 import DownloadButton from "./DownloadButton";
-import { BookData } from "../interfaces";
+import { BookData, FulfillmentLink } from "../interfaces";
 import { AudioHeadphoneIcon, BookIcon } from "@nypl/dgx-svg-icons";
 const download = require("downloadjs");
 
 export interface BookProps {
   book: BookData;
   collectionUrl?: string;
-  updateBook: (url: string) => Promise<BookData>;
+  updateBook: (url: string | undefined) => Promise<BookData>;
   fulfillBook: (url: string) => Promise<Blob>;
   indirectFulfillBook: (url: string, type: string) => Promise<string>;
   isSignedIn?: boolean;
@@ -40,7 +40,7 @@ export default class Book<P extends BookProps> extends React.Component<P, {}> {
         ? book.contributors.join(", ")
         : "";
     // Display contributors only if there are no authors.
-    const authors = hasAuthors ? book.authors.join(", ") : contributors;
+    const authors = hasAuthors ? book.authors?.join(", ") : contributors;
 
     return (
       <div className={`book ${showMediaIconClass}`} lang={book.language}>
@@ -142,12 +142,12 @@ export default class Book<P extends BookProps> extends React.Component<P, {}> {
     // Links are ordered so that the first link should be the most useful.
     // That way compact views can display only the first link.
 
-    let links = [];
+    let links: JSX.Element[] = [];
 
     if (this.isOpenAccess()) {
       if (this.props.epubReaderUrlTemplate) {
         let index = 0;
-        for (const link of this.props.book.openAccessLinks) {
+        for (const link of this.props.book.openAccessLinks ?? []) {
           if (link.type === "application/epub+zip") {
             links.push(
               <span key={`${link.url}-${index}`}>
@@ -165,27 +165,25 @@ export default class Book<P extends BookProps> extends React.Component<P, {}> {
         }
       }
 
-      links.push(
-        this.props.book.openAccessLinks.map((link, index) => {
-          return (
-            <DownloadButton
-              key={`${link.url}-${index}`}
-              url={link.url}
-              mimeType={link.type}
-              isPlainLink={true}
-            />
-          );
-        })
-      );
+      this.props.book.openAccessLinks?.forEach((link, index) => {
+        links.push(
+          <DownloadButton
+            key={`${link.url}-${index}`}
+            url={link.url}
+            mimeType={link.type}
+            isPlainLink={true}
+          />
+        );
+      });
     } else if (this.isBorrowed()) {
       // Put streaming links first, followed by a disabled "Borrowed" button that will
       // display in the list view if streaming is not available.
 
       let streamingMediaType =
         "text/html;profile=http://librarysimplified.org/terms/profiles/streaming-media";
-      let streamingLinks = [];
-      let downloadLinks = [];
-      for (let link of this.props.book.fulfillmentLinks) {
+      let streamingLinks: FulfillmentLink[] = [];
+      let downloadLinks: FulfillmentLink[] = [];
+      for (let link of this.props.book.fulfillmentLinks ?? []) {
         if (
           link.type === streamingMediaType ||
           link.indirectType === streamingMediaType
@@ -196,23 +194,21 @@ export default class Book<P extends BookProps> extends React.Component<P, {}> {
         }
       }
 
-      links.push(
-        streamingLinks.map((link, index) => {
-          let isDirectStreaming = link.type === streamingMediaType;
-          return (
-            <DownloadButton
-              key={`${link.url}-${index}`}
-              fulfill={this.props.fulfillBook}
-              indirectFulfill={this.props.indirectFulfillBook}
-              url={link.url}
-              mimeType={link.type}
-              title={this.props.book.title}
-              isPlainLink={isDirectStreaming || !this.props.isSignedIn}
-              indirectType={link.indirectType}
-            />
-          );
-        })
-      );
+      streamingLinks.forEach((link, index) => {
+        let isDirectStreaming = link.type === streamingMediaType;
+        links.push(
+          <DownloadButton
+            key={`${link.url}-${index}`}
+            fulfill={this.props.fulfillBook}
+            indirectFulfill={this.props.indirectFulfillBook}
+            url={link.url}
+            mimeType={link.type}
+            title={this.props.book.title}
+            isPlainLink={isDirectStreaming || !this.props.isSignedIn}
+            indirectType={link.indirectType}
+          />
+        );
+      });
       links.push(
         <BorrowButton
           key={this.props.book.borrowUrl}
@@ -223,22 +219,20 @@ export default class Book<P extends BookProps> extends React.Component<P, {}> {
           Borrowed
         </BorrowButton>
       );
-      links.push(
-        downloadLinks.map((link, index) => {
-          return (
-            <DownloadButton
-              key={`${link.url}-${index}`}
-              fulfill={this.props.fulfillBook}
-              indirectFulfill={this.props.indirectFulfillBook}
-              url={link.url}
-              mimeType={link.type}
-              title={this.props.book.title}
-              isPlainLink={!this.props.isSignedIn}
-              indirectType={link.indirectType}
-            />
-          );
-        })
-      );
+      downloadLinks.forEach((link, index) => {
+        links.push(
+          <DownloadButton
+            key={`${link.url}-${index}`}
+            fulfill={this.props.fulfillBook}
+            indirectFulfill={this.props.indirectFulfillBook}
+            url={link.url}
+            mimeType={link.type}
+            title={this.props.book.title}
+            isPlainLink={!this.props.isSignedIn}
+            indirectType={link.indirectType}
+          />
+        );
+      });
     }
 
     if (this.isReserved()) {

--- a/packages/opds-web-client/src/components/BookCover.tsx
+++ b/packages/opds-web-client/src/components/BookCover.tsx
@@ -47,7 +47,7 @@ export default class BookCover extends React.Component<
     }
 
     let titleFontSize = this.computeFontSize(title, 40);
-    let authorFontSize = this.computeFontSize(authors.join(", "), 25);
+    let authorFontSize = this.computeFontSize(authors?.join(", ") ?? "", 25);
 
     let hue = this.seededRandomHue(title);
     let bgColor = `hsla(${hue}, 40%, 60%, 1)`;
@@ -57,7 +57,7 @@ export default class BookCover extends React.Component<
         <div className="title" style={{ fontSize: titleFontSize }}>
           {title}
         </div>
-        {authors.length && (
+        {authors?.length && (
           <div className="authors" style={{ fontSize: authorFontSize }}>
             By {authors.join(", ")}
           </div>
@@ -66,7 +66,7 @@ export default class BookCover extends React.Component<
     );
   }
 
-  computeFontSize(text, baseFontSize = 40, minFontSize = 15) {
+  computeFontSize(text: string, baseFontSize = 40, minFontSize = 15) {
     // decrease size as max word length increases
     // decrease size as word count grows beyond 3
     let words = text.split(/\s/);

--- a/packages/opds-web-client/src/components/BookDetails.tsx
+++ b/packages/opds-web-client/src/components/BookDetails.tsx
@@ -70,7 +70,7 @@ export default class BookDetails<P extends BookDetailsProps> extends Book<P> {
           <div
             className="summary"
             lang={this.props.book.language}
-            dangerouslySetInnerHTML={{ __html: this.props.book.summary }}
+            dangerouslySetInnerHTML={{ __html: this.props.book.summary ?? "" }}
           ></div>
         </div>
       </div>
@@ -116,7 +116,7 @@ export default class BookDetails<P extends BookDetailsProps> extends Book<P> {
       return [];
     }
 
-    let info = [];
+    let info: JSX.Element[] = [];
 
     let availableCopies =
       this.props.book.copies && this.props.book.copies.available;

--- a/packages/opds-web-client/src/components/Breadcrumbs.tsx
+++ b/packages/opds-web-client/src/components/Breadcrumbs.tsx
@@ -8,7 +8,10 @@ export interface BreadcrumbsProps extends React.Props<{}> {
 }
 
 export interface ComputeBreadcrumbs {
-  (collection: CollectionData, history: LinkData[]): LinkData[];
+  (
+    collection: CollectionData | null | undefined,
+    history: LinkData[] | null | undefined
+  ): LinkData[];
 }
 
 /** Shows a list of breadcrumbs links above a collection. */

--- a/packages/opds-web-client/src/components/Breadcrumbs.tsx
+++ b/packages/opds-web-client/src/components/Breadcrumbs.tsx
@@ -65,7 +65,7 @@ export function hierarchyComputeBreadcrumbs(
   history: LinkData[],
   comparator?: (url1: string, url2: string) => boolean
 ): LinkData[] {
-  let links = [];
+  let links: LinkData[] = [];
 
   if (!collection) {
     return [];

--- a/packages/opds-web-client/src/components/CatalogLink.tsx
+++ b/packages/opds-web-client/src/components/CatalogLink.tsx
@@ -4,8 +4,8 @@ import { Link, Router } from "react-router";
 import { NavigateContext, Router as RouterType } from "../interfaces";
 
 export interface CatalogLinkProps extends React.HTMLProps<{}> {
-  collectionUrl?: string;
-  bookUrl?: string;
+  collectionUrl?: string | null;
+  bookUrl?: string | null;
 }
 
 /** Shows a link to another collection or book in the same OPDS catalog. */
@@ -38,9 +38,9 @@ export default class CatalogLink extends React.Component<CatalogLinkProps, {}> {
   }
 
   render(): JSX.Element {
-    let { collectionUrl, bookUrl, ...props } = this.props;
-    collectionUrl = collectionUrl || null;
-    bookUrl = bookUrl || null;
+    let { collectionUrl = null, bookUrl = null, ...props } = this.props;
+    // collectionUrl = collectionUrl || null;
+    // bookUrl = bookUrl || null;
 
     let location = this.context.pathFor(collectionUrl, bookUrl);
 

--- a/packages/opds-web-client/src/components/Collection.tsx
+++ b/packages/opds-web-client/src/components/Collection.tsx
@@ -44,10 +44,10 @@ export default class Collection extends React.Component<CollectionProps, {}> {
   }
 
   render(): JSX.Element {
-    let hasFacets =
+    const hasFacets =
       this.props.collection.facetGroups &&
       this.props.collection.facetGroups.length > 0;
-    let hasViews =
+    const hasViews =
       this.props.collection.books && this.props.collection.books.length > 0;
 
     return (
@@ -55,7 +55,7 @@ export default class Collection extends React.Component<CollectionProps, {}> {
         {hasFacets && (
           <div className="facet-groups" aria-label="filters">
             <SkipNavigationLink target="#collection-main" label="filters" />
-            {this.props.collection.facetGroups.map(facetGroup => (
+            {this.props.collection.facetGroups?.map(facetGroup => (
               <FacetGroup key={facetGroup.label} facetGroup={facetGroup} />
             ))}
           </div>
@@ -210,13 +210,15 @@ export default class Collection extends React.Component<CollectionProps, {}> {
     return (
       !this.props.hidden &&
       !this.props.isFetchingPage &&
-      this.props.collection.nextPageUrl
+      !!this.props.collection.nextPageUrl
     );
   }
 
   fetch() {
-    if (this.canFetch()) {
-      this.props.fetchPage(this.props.collection.nextPageUrl);
+    // had to move this typeguard into here for typescript to
+    // believe the nextPageUrl was defined.
+    if (this.canFetch() && this.props.collection.nextPageUrl) {
+      this.props.fetchPage?.(this.props.collection.nextPageUrl);
     }
   }
 

--- a/packages/opds-web-client/src/components/DownloadButton.tsx
+++ b/packages/opds-web-client/src/components/DownloadButton.tsx
@@ -7,7 +7,7 @@ export interface DownloadButtonProps extends React.HTMLProps<{}> {
   mimeType: string;
   isPlainLink?: boolean;
   fulfill?: (url: string) => Promise<Blob>;
-  indirectFulfill?: (url: string, type: string) => Promise<string>;
+  indirectFulfill?: (url: string, type: string | undefined) => Promise<string>;
   title?: string;
   indirectType?: string;
 }
@@ -68,15 +68,20 @@ export default class DownloadButton extends React.Component<
   fulfill() {
     if (this.isIndirect()) {
       return this.props
-        .indirectFulfill(this.props.url, this.props.indirectType)
+        .indirectFulfill?.(this.props.url, this.props.indirectType)
         .then(url => {
           window.open(url, "_blank");
         });
     } else {
-      return this.props.fulfill(this.props.url).then(blob => {
+      return this.props.fulfill?.(this.props.url).then(blob => {
         download(
           blob,
-          generateFilename(this.props.title, this.fileExtension()),
+          generateFilename(
+            // the following is meant to smoothly handle the case where
+            // this.props.title is undefined or null
+            this.props.title ?? "untitled",
+            this.fileExtension()
+          ),
           // TODO: use mimeType variable once we fix the link type in our OPDS entries
           this.mimeType()
         );

--- a/packages/opds-web-client/src/components/FacetGroup.tsx
+++ b/packages/opds-web-client/src/components/FacetGroup.tsx
@@ -18,7 +18,10 @@ export default class FacetGroup extends React.Component<FacetGroupProps, {}> {
           className="subtle-list"
         >
           {this.props.facetGroup.facets.map(facet => (
-            <li key={facet.label} className={facet.active ? "active" : null}>
+            <li
+              key={facet.label}
+              className={facet.active ? "active" : undefined}
+            >
               <CatalogLink className="facetLink" collectionUrl={facet.href}>
                 {facet.label}
               </CatalogLink>

--- a/packages/opds-web-client/src/components/Lane.tsx
+++ b/packages/opds-web-client/src/components/Lane.tsx
@@ -31,7 +31,7 @@ export default class Lane extends React.Component<LaneProps, LaneState> {
     this.updateScrollButtons = this.updateScrollButtons.bind(this);
   }
 
-  render(): JSX.Element {
+  render() {
     let visibleBooks = this.visibleBooks();
 
     if (visibleBooks.length === 0) {
@@ -100,7 +100,9 @@ export default class Lane extends React.Component<LaneProps, LaneState> {
     }
 
     return this.props.lane.books.filter(
-      book => this.props.hiddenBookIds.indexOf(book.id) === -1
+      // the following optional chaining will ensure it evaluates to false if
+      // hiddenBookIds is undefined
+      book => this.props.hiddenBookIds?.indexOf(book.id) === -1
     );
   }
 

--- a/packages/opds-web-client/src/components/Root.tsx
+++ b/packages/opds-web-client/src/components/Root.tsx
@@ -36,12 +36,12 @@ import {
 import AuthPlugin from "../AuthPlugin";
 
 export interface HeaderProps extends React.Props<{}> {
-  collectionTitle: string;
-  bookTitle: string;
+  collectionTitle: string | null;
+  bookTitle: string | null;
   loansUrl?: string;
-  isSignedIn: boolean;
+  isSignedIn?: boolean;
   fetchLoans?: (url: string) => Promise<CollectionData>;
-  clearAuthCredentials: () => void;
+  clearAuthCredentials?: () => void;
 }
 
 export interface FooterProps extends React.Props<{}> {
@@ -53,10 +53,10 @@ export interface CollectionContainerProps extends React.Props<{}> {
 }
 
 export interface BookDetailsContainerProps extends React.Props<{}> {
-  bookUrl: string;
-  collectionUrl: string;
-  refreshCatalog: () => Promise<any>;
-  book: BookData;
+  bookUrl?: string;
+  collectionUrl?: string;
+  refreshCatalog?: () => Promise<any>;
+  book?: BookData | null;
 }
 
 export interface RootProps extends StateProps {
@@ -67,8 +67,8 @@ export interface RootProps extends StateProps {
   proxyUrl?: string;
   dispatch?: any;
   setCollectionAndBook?: (
-    collectionUrl: string,
-    bookUrl: string
+    collectionUrl?: string,
+    bookUrl?: string
   ) => Promise<any>;
   clearCollection?: () => void;
   clearBook?: () => void;
@@ -85,9 +85,9 @@ export interface RootProps extends StateProps {
   CollectionContainer?: React.ComponentClass<CollectionContainerProps, {}>;
   BookDetailsContainer?: React.ComponentClass<BookDetailsContainerProps, {}>;
   computeBreadcrumbs?: ComputeBreadcrumbs;
-  updateBook?: (url: string) => Promise<BookData>;
-  fulfillBook?: (url: string) => Promise<Blob>;
-  indirectFulfillBook?: (url: string, type: string) => Promise<string>;
+  updateBook: (url: string) => Promise<BookData>;
+  fulfillBook: (url: string) => Promise<Blob>;
+  indirectFulfillBook: (url: string, type: string) => Promise<string>;
   fetchLoans?: (url: string) => Promise<CollectionData>;
   saveAuthCredentials?: (credentials: AuthCredentials) => void;
   clearAuthCredentials?: () => void;
@@ -97,12 +97,12 @@ export interface RootProps extends StateProps {
     title: string
   ) => void;
   closeErrorAndHideAuthForm?: () => void;
-  setPreference?: (key: string, value: string) => void;
+  setPreference: (key: string, value: string) => void;
   allLanguageSearch?: boolean;
 }
 
 export interface RootState {
-  authError?: string;
+  authError?: string | null;
 }
 
 /** The root component of the application that connects to the Redux store and
@@ -112,7 +112,7 @@ export class Root extends React.Component<RootProps, RootState> {
 
   static contextTypes: React.ValidationMap<NavigateContext> = {
     router: PropTypes.object as React.Validator<RouterType>,
-    pathFor: PropTypes.func
+    pathFor: PropTypes.func.isRequired
   };
 
   constructor(props) {
@@ -138,14 +138,13 @@ export class Root extends React.Component<RootProps, RootState> {
     );
 
     let showCollection = this.props.collectionData && !this.props.bookData;
-    let showBook = this.props.bookData;
+    const showBook = !!this.props.bookData;
     let showBookWrapper = this.props.bookUrl || this.props.bookData;
     let showUrlForm = !this.props.collectionUrl && !this.props.bookUrl;
     let showBreadcrumbs =
       this.props.collectionData && breadcrumbsLinks.length > 0;
     let showSearch =
       this.props.collectionData && this.props.collectionData.search;
-    let showFooter = this.props.collectionData && Footer;
     // The tabs should only display if the component is passed and if
     // the catalog is being displayed and not a book.
     let showCollectionContainer = !!CollectionContainer && !showBook;
@@ -154,8 +153,8 @@ export class Root extends React.Component<RootProps, RootState> {
       this.props.error && (!this.props.auth || !this.props.auth.showForm);
     let errorMessage = "";
     if (hasError) {
-      errorMessage = `Could not fetch data: ${this.props.error.url}\n
-        ${this.props.error.response}`;
+      errorMessage = `Could not fetch data: ${this.props.error?.url}\n
+        ${this.props.error?.response}`;
     }
 
     return (
@@ -173,8 +172,8 @@ export class Root extends React.Component<RootProps, RootState> {
           >
             {showSearch && (
               <Search
-                url={this.props.collectionData.search.url}
-                searchData={this.props.collectionData.search.searchData}
+                url={this.props.collectionData?.search?.url}
+                searchData={this.props.collectionData?.search?.searchData}
                 fetchSearchDescription={this.props.fetchSearchDescription}
                 allLanguageSearch={allLanguageSearch}
               />
@@ -215,8 +214,8 @@ export class Root extends React.Component<RootProps, RootState> {
             )}
             {showSearch && (
               <Search
-                url={this.props.collectionData.search.url}
-                searchData={this.props.collectionData.search.searchData}
+                url={this.props.collectionData?.search?.url}
+                searchData={this.props.collectionData?.search?.searchData}
                 fetchSearchDescription={this.props.fetchSearchDescription}
                 allLanguageSearch={allLanguageSearch}
               />
@@ -263,15 +262,15 @@ export class Root extends React.Component<RootProps, RootState> {
           <div className="body">
             {showBookWrapper && (
               <div className="book-details-wrapper">
-                {showBook &&
+                {this.props.bookData &&
                   (BookDetailsContainer &&
-                  (this.props.bookUrl || this.props.bookData.url) ? (
+                  (this.props.bookUrl || this.props.bookData?.url) ? (
                     <BookDetailsContainer
                       book={this.loanedBookData(
                         this.props.bookData,
                         this.props.bookUrl
                       )}
-                      bookUrl={this.props.bookUrl || this.props.bookData.url}
+                      bookUrl={this.props.bookUrl || this.props.bookData?.url}
                       collectionUrl={this.props.collectionUrl}
                       refreshCatalog={this.props.refreshCollectionAndBook}
                     >
@@ -305,9 +304,27 @@ export class Root extends React.Component<RootProps, RootState> {
               </div>
             )}
 
-            {showCollection ? (
-              showCollectionContainer ? (
-                <CollectionContainer>
+            {CollectionContainer &&
+              (showCollection ? (
+                showCollectionContainer ? (
+                  <CollectionContainer>
+                    <Collection
+                      collection={this.collectionDataWithLoans()}
+                      fetchPage={this.props.fetchPage}
+                      isFetchingCollection={this.props.isFetchingCollection}
+                      isFetchingBook={this.props.isFetchingBook}
+                      isFetchingPage={this.props.isFetchingPage}
+                      error={this.props.error}
+                      updateBook={this.props.updateBook}
+                      fulfillBook={this.props.fulfillBook}
+                      indirectFulfillBook={this.props.indirectFulfillBook}
+                      isSignedIn={this.props.isSignedIn}
+                      epubReaderUrlTemplate={this.props.epubReaderUrlTemplate}
+                      preferences={this.props.preferences}
+                      setPreference={this.props.setPreference}
+                    />
+                  </CollectionContainer>
+                ) : (
                   <Collection
                     collection={this.collectionDataWithLoans()}
                     fetchPage={this.props.fetchPage}
@@ -323,28 +340,11 @@ export class Root extends React.Component<RootProps, RootState> {
                     preferences={this.props.preferences}
                     setPreference={this.props.setPreference}
                   />
-                </CollectionContainer>
-              ) : (
-                <Collection
-                  collection={this.collectionDataWithLoans()}
-                  fetchPage={this.props.fetchPage}
-                  isFetchingCollection={this.props.isFetchingCollection}
-                  isFetchingBook={this.props.isFetchingBook}
-                  isFetchingPage={this.props.isFetchingPage}
-                  error={this.props.error}
-                  updateBook={this.props.updateBook}
-                  fulfillBook={this.props.fulfillBook}
-                  indirectFulfillBook={this.props.indirectFulfillBook}
-                  isSignedIn={this.props.isSignedIn}
-                  epubReaderUrlTemplate={this.props.epubReaderUrlTemplate}
-                  preferences={this.props.preferences}
-                  setPreference={this.props.setPreference}
-                />
-              )
-            ) : null}
+                )
+              ) : null)}
           </div>
         </main>
-        {showFooter && (
+        {Footer && this.props.collectionData && (
           <footer>
             <Footer collection={this.props.collectionData} />
           </footer>
@@ -377,14 +377,14 @@ export class Root extends React.Component<RootProps, RootState> {
       this.setState({ authError });
     } else if (this.props.collectionUrl || this.props.bookUrl) {
       return this.props
-        .setCollectionAndBook(this.props.collectionUrl, this.props.bookUrl)
+        .setCollectionAndBook?.(this.props.collectionUrl, this.props.bookUrl)
         .then(({ collectionData, bookData }) => {
           if (
             this.props.authCredentials &&
             collectionData &&
             collectionData.shelfUrl
           ) {
-            this.props.fetchLoans(collectionData.shelfUrl);
+            this.props.fetchLoans?.(collectionData.shelfUrl);
           }
         });
     }
@@ -395,7 +395,7 @@ export class Root extends React.Component<RootProps, RootState> {
       nextProps.collectionUrl !== this.props.collectionUrl ||
       nextProps.bookUrl !== this.props.bookUrl
     ) {
-      this.props.setCollectionAndBook(
+      this.props.setCollectionAndBook?.(
         nextProps.collectionUrl,
         nextProps.bookUrl
       );
@@ -445,7 +445,7 @@ export class Root extends React.Component<RootProps, RootState> {
     }
   }
 
-  loanedBookData(book: BookData | null, bookUrl?: string): BookData {
+  loanedBookData(book: BookData, bookUrl?: string): BookData {
     if (!this.props.loans || this.props.loans.length === 0) {
       return book;
     }
@@ -467,7 +467,7 @@ export class Root extends React.Component<RootProps, RootState> {
     // loaned version. This currently only changes ungrouped books, not books in lanes,
     // since lanes don't need any loan-related information.
     return Object.assign({}, this.props.collectionData, {
-      books: this.props.collectionData.books.map(book =>
+      books: this.props.collectionData?.books.map(book =>
         this.loanedBookData(book)
       )
     });

--- a/packages/opds-web-client/src/components/Root.tsx
+++ b/packages/opds-web-client/src/components/Root.tsx
@@ -304,27 +304,9 @@ export class Root extends React.Component<RootProps, RootState> {
               </div>
             )}
 
-            {CollectionContainer &&
-              (showCollection ? (
-                showCollectionContainer ? (
-                  <CollectionContainer>
-                    <Collection
-                      collection={this.collectionDataWithLoans()}
-                      fetchPage={this.props.fetchPage}
-                      isFetchingCollection={this.props.isFetchingCollection}
-                      isFetchingBook={this.props.isFetchingBook}
-                      isFetchingPage={this.props.isFetchingPage}
-                      error={this.props.error}
-                      updateBook={this.props.updateBook}
-                      fulfillBook={this.props.fulfillBook}
-                      indirectFulfillBook={this.props.indirectFulfillBook}
-                      isSignedIn={this.props.isSignedIn}
-                      epubReaderUrlTemplate={this.props.epubReaderUrlTemplate}
-                      preferences={this.props.preferences}
-                      setPreference={this.props.setPreference}
-                    />
-                  </CollectionContainer>
-                ) : (
+            {showCollection ? (
+              showCollectionContainer && CollectionContainer ? (
+                <CollectionContainer>
                   <Collection
                     collection={this.collectionDataWithLoans()}
                     fetchPage={this.props.fetchPage}
@@ -340,8 +322,25 @@ export class Root extends React.Component<RootProps, RootState> {
                     preferences={this.props.preferences}
                     setPreference={this.props.setPreference}
                   />
-                )
-              ) : null)}
+                </CollectionContainer>
+              ) : (
+                <Collection
+                  collection={this.collectionDataWithLoans()}
+                  fetchPage={this.props.fetchPage}
+                  isFetchingCollection={this.props.isFetchingCollection}
+                  isFetchingBook={this.props.isFetchingBook}
+                  isFetchingPage={this.props.isFetchingPage}
+                  error={this.props.error}
+                  updateBook={this.props.updateBook}
+                  fulfillBook={this.props.fulfillBook}
+                  indirectFulfillBook={this.props.indirectFulfillBook}
+                  isSignedIn={this.props.isSignedIn}
+                  epubReaderUrlTemplate={this.props.epubReaderUrlTemplate}
+                  preferences={this.props.preferences}
+                  setPreference={this.props.setPreference}
+                />
+              )
+            ) : null}
           </div>
         </main>
         {Footer && this.props.collectionData && (

--- a/packages/opds-web-client/src/components/Search.tsx
+++ b/packages/opds-web-client/src/components/Search.tsx
@@ -54,7 +54,7 @@ export default class Search extends React.Component<SearchProps, {}> {
 
   componentWillMount() {
     if (this.props.url) {
-      this.props.fetchSearchDescription(this.props.url);
+      this.props.fetchSearchDescription?.(this.props.url);
     }
   }
 
@@ -66,11 +66,11 @@ export default class Search extends React.Component<SearchProps, {}> {
 
   onSubmit(event) {
     let searchTerms = encodeURIComponent(this.refs["input"]["value"]);
-    let url = this.props.searchData.template(searchTerms);
+    let url = this.props.searchData?.template(searchTerms);
     if (this.props.allLanguageSearch) {
       url += "&language=all";
     }
-    this.context.router.push(this.context.pathFor(url, null));
+    this.context.router?.push(this.context.pathFor(url, null));
     event.preventDefault();
   }
 }

--- a/packages/opds-web-client/src/components/UrlForm.tsx
+++ b/packages/opds-web-client/src/components/UrlForm.tsx
@@ -53,7 +53,7 @@ export default class UrlForm extends React.Component<UrlFormProps, {}> {
 
     const url = this.inputRef.current && this.inputRef.current.value;
     if (url !== "") {
-      this.context.router.push(this.context.pathFor(url, null));
+      this.context.router?.push(this.context.pathFor(url, null));
     }
   }
 }

--- a/packages/opds-web-client/src/components/__tests__/Book-test.tsx
+++ b/packages/opds-web-client/src/components/__tests__/Book-test.tsx
@@ -168,7 +168,7 @@ describe("Book", () => {
       let authors = bookInfo.find(".authors");
 
       expect(title.text()).to.equal(book.title);
-      expect(authors.text()).to.equal(`By ${book.authors.join(", ")}`);
+      expect(authors.text()).to.equal(`By ${book.authors?.join(", ")}`);
     });
 
     it("shows contributors when there's no author", () => {
@@ -237,7 +237,7 @@ describe("Book", () => {
       let authors = bookInfo.find(".authors");
 
       expect(title.text()).to.equal(book.title);
-      expect(authors.text()).to.equal(`By ${book.authors.join(", ")}`);
+      expect(authors.text()).to.equal(`By ${book.authors?.join(", ")}`);
     });
 
     it("shows contributors when there's no author", () => {
@@ -262,7 +262,7 @@ describe("Book", () => {
     it("shows series", () => {
       let bookInfo = wrapper.find(".expanded-info");
       let series = bookInfo.find(".series");
-      expect(series.text()).to.equal(book.series.name);
+      expect(series.text()).to.equal(book.series?.name);
     });
 
     it("shows publisher", () => {

--- a/packages/opds-web-client/src/components/__tests__/BookDetails-test.tsx
+++ b/packages/opds-web-client/src/components/__tests__/BookDetails-test.tsx
@@ -71,18 +71,18 @@ describe("BookDetails", () => {
 
   it("shows series", () => {
     let series = wrapper.find(".series");
-    expect(series.text()).to.equal(book.series.name);
+    expect(series.text()).to.equal(book.series?.name);
   });
 
   it("shows authors", () => {
     let author = wrapper.find(".authors");
-    expect(author.text()).to.equal(`By ${book.authors.join(", ")}`);
+    expect(author.text()).to.equal(`By ${book.authors?.join(", ")}`);
   });
 
   it("shows contributors", () => {
     let contributor = wrapper.find(".contributors");
     expect(contributor.text()).to.equal(
-      "Contributors: " + book.contributors.join(", ")
+      "Contributors: " + book.contributors?.join(", ")
     );
   });
 

--- a/packages/opds-web-client/src/components/__tests__/Root-test.tsx
+++ b/packages/opds-web-client/src/components/__tests__/Root-test.tsx
@@ -30,6 +30,31 @@ import {
 import { State } from "../../state";
 import { CollectionData, BookData, LinkData } from "../../interfaces";
 import { mockRouterContext } from "../../__mocks__/routing";
+import AuthPlugin from "../../AuthPlugin";
+
+let book: BookData = {
+  id: "urn:librarysimplified.org/terms/id/3M%20ID/crrmnr9",
+  title: "The Mayan Secrets",
+  authors: ["Clive Cussler", "Thomas Perry"],
+  summary:
+    "<strong>Sam and Remi Fargo race for treasure&#8212;and survival&#8212;in this lightning-paced new adventure from #1&lt;i&gt; New York Times&lt;/i&gt; bestselling author Clive Cussler.</strong><br />Husband-and-wife team Sam and Remi Fargo are in Mexico when they come upon a remarkable discovery&#8212;the mummified remainsof a man clutching an ancient sealed pot. Within the pot is a Mayan book larger than any known before.<br />The book contains astonishing information about the Mayans, their cities, and about mankind itself. The secrets are so powerful that some people would do anything to possess them&#8212;as the Fargos are about to find out.",
+  imageUrl: "https://dlotdqc6pnwqb.cloudfront.net/3M/crrmnr9/cover.jpg",
+  openAccessLinks: [
+    { url: "secrets.epub", type: "application/epub+zip" },
+    { url: "secrets.mobi", type: "application/x-mobipocket-ebook" }
+  ],
+  borrowUrl: "borrow url",
+  publisher: "Penguin Publishing Group",
+  published: "February 29, 2016",
+  categories: ["category 1", "category 2"],
+  series: {
+    name: "Fake Series"
+  },
+  language: "de",
+  raw: {
+    $: { "schema:additionalType": { value: "http://bib.schema.org/Audiobook" } }
+  }
+};
 
 const setCollectionAndBookPromise = new Promise((resolve, reject) => {
   resolve({
@@ -38,17 +63,38 @@ const setCollectionAndBookPromise = new Promise((resolve, reject) => {
   });
 });
 const mockSetCollectionAndBook = stub().returns(setCollectionAndBookPromise);
+const fulfillBook = async (url: string): Promise<Blob> => new Blob();
+const updateBook = async (url: string): Promise<BookData> => book;
+const indirectFulfillBook = async (
+  url: string,
+  type: string
+): Promise<string> => "test value";
+const setPreference = () => null;
 
 describe("Root", () => {
   it("shows skip navigation link", () => {
-    let wrapper = shallow(<Root />);
+    let wrapper = shallow(
+      <Root
+        fulfillBook={fulfillBook}
+        indirectFulfillBook={indirectFulfillBook}
+        updateBook={updateBook}
+        setPreference={setPreference}
+      />
+    );
 
     let links = wrapper.find(SkipNavigationLink);
     expect(links.length).to.equal(1);
   });
 
   it("contains main element", () => {
-    let wrapper = shallow(<Root />);
+    let wrapper = shallow(
+      <Root
+        fulfillBook={fulfillBook}
+        indirectFulfillBook={indirectFulfillBook}
+        updateBook={updateBook}
+        setPreference={setPreference}
+      />
+    );
 
     let main = wrapper.find("main");
     expect(main.props().role).to.equal("main");
@@ -68,6 +114,10 @@ describe("Root", () => {
     let fetchSearchDescription = (url: string) => {};
     let wrapper = shallow(
       <Root
+        fulfillBook={fulfillBook}
+        indirectFulfillBook={indirectFulfillBook}
+        updateBook={updateBook}
+        setPreference={setPreference}
         collectionData={collectionData}
         fetchSearchDescription={fetchSearchDescription}
       />
@@ -85,7 +135,15 @@ describe("Root", () => {
 
   it("shows a collection if props include collectionData", () => {
     let collectionData: CollectionData = groupedCollectionData;
-    let wrapper = shallow(<Root collectionData={collectionData} />);
+    let wrapper = shallow(
+      <Root
+        fulfillBook={fulfillBook}
+        indirectFulfillBook={indirectFulfillBook}
+        updateBook={updateBook}
+        setPreference={setPreference}
+        collectionData={collectionData}
+      />
+    );
 
     let collections = wrapper.find(Collection);
     expect(collections.length).to.equal(1);
@@ -102,7 +160,14 @@ describe("Root", () => {
     });
     let loans = [loan];
     let wrapper = shallow(
-      <Root collectionData={collectionData} loans={loans} />
+      <Root
+        fulfillBook={fulfillBook}
+        indirectFulfillBook={indirectFulfillBook}
+        updateBook={updateBook}
+        setPreference={setPreference}
+        collectionData={collectionData}
+        loans={loans}
+      />
     );
     let collections = wrapper.find(Collection);
     expect(collections.length).to.equal(1);
@@ -120,7 +185,14 @@ describe("Root", () => {
   });
 
   it("shows a url form if no collection url or book url", () => {
-    let wrapper = shallow(<Root />);
+    let wrapper = shallow(
+      <Root
+        fulfillBook={fulfillBook}
+        indirectFulfillBook={indirectFulfillBook}
+        updateBook={updateBook}
+        setPreference={setPreference}
+      />
+    );
 
     let urlForms = wrapper.find(UrlForm);
     expect(urlForms.length).to.equal(1);
@@ -129,6 +201,10 @@ describe("Root", () => {
   it("doesn't show a url form if collection url", () => {
     let wrapper = shallow(
       <Root
+        fulfillBook={fulfillBook}
+        indirectFulfillBook={indirectFulfillBook}
+        updateBook={updateBook}
+        setPreference={setPreference}
         collectionUrl="test"
         setCollectionAndBook={mockSetCollectionAndBook}
       />
@@ -140,7 +216,14 @@ describe("Root", () => {
 
   it("doesn't show a url form if book url", () => {
     let wrapper = shallow(
-      <Root bookUrl="test" setCollectionAndBook={mockSetCollectionAndBook} />
+      <Root
+        fulfillBook={fulfillBook}
+        indirectFulfillBook={indirectFulfillBook}
+        updateBook={updateBook}
+        setPreference={setPreference}
+        bookUrl="test"
+        setCollectionAndBook={mockSetCollectionAndBook}
+      />
     );
 
     let urlForms = wrapper.find(UrlForm);
@@ -153,6 +236,10 @@ describe("Root", () => {
     let setCollectionAndBook = stub().returns(setCollectionAndBookPromise);
     let wrapper = shallow(
       <Root
+        fulfillBook={fulfillBook}
+        indirectFulfillBook={indirectFulfillBook}
+        updateBook={updateBook}
+        setPreference={setPreference}
         collectionUrl={collectionUrl}
         setCollectionAndBook={setCollectionAndBook}
       />
@@ -167,7 +254,14 @@ describe("Root", () => {
     let bookUrl = "http://example.com/book";
     let setCollectionAndBook = stub().returns(setCollectionAndBookPromise);
     let wrapper = shallow(
-      <Root bookUrl={bookUrl} setCollectionAndBook={setCollectionAndBook} />
+      <Root
+        bookUrl={bookUrl}
+        setCollectionAndBook={setCollectionAndBook}
+        fulfillBook={fulfillBook}
+        indirectFulfillBook={indirectFulfillBook}
+        updateBook={updateBook}
+        setPreference={setPreference}
+      />
     );
 
     expect(setCollectionAndBook.callCount).to.equal(1);
@@ -196,6 +290,10 @@ describe("Root", () => {
         setCollectionAndBook={setCollectionAndBook}
         fetchLoans={fetchLoans}
         authCredentials={credentials}
+        fulfillBook={fulfillBook}
+        indirectFulfillBook={indirectFulfillBook}
+        updateBook={updateBook}
+        setPreference={setPreference}
       />
     );
 
@@ -214,7 +312,13 @@ describe("Root", () => {
 
   it("updates page title on mount", () => {
     let wrapper = shallow(
-      <Root pageTitleTemplate={(collection, book) => "page title"} />
+      <Root
+        pageTitleTemplate={(collection, book) => "page title"}
+        fulfillBook={fulfillBook}
+        indirectFulfillBook={indirectFulfillBook}
+        updateBook={updateBook}
+        setPreference={setPreference}
+      />
     );
     expect(document.title).to.equal("page title");
   });
@@ -226,27 +330,39 @@ describe("Root", () => {
       <Root
         saveAuthCredentials={saveAuthCredentials}
         authCredentials={credentials}
+        fulfillBook={fulfillBook}
+        indirectFulfillBook={indirectFulfillBook}
+        updateBook={updateBook}
+        setPreference={setPreference}
       />
     );
     expect(saveAuthCredentials.callCount).to.equal(1);
     expect(saveAuthCredentials.args[0][0]).to.equal(credentials);
   });
 
+  const basicProps = {
+    fulfillBook,
+    indirectFulfillBook,
+    updateBook,
+    setPreference
+  };
+
   it("checks for credentials on mount", () => {
     let credentials = { provider: "test", credentials: "credentials" };
-    let plugin = {
+    let plugin: AuthPlugin = {
       type: "test",
       lookForCredentials: stub().returns({ credentials }),
-      formComponent: null,
-      buttonComponent: null
+      formComponent: stub(),
+      buttonComponent: stub()
     };
     let propsWithAuthPlugin = {
       authPlugins: [plugin],
-      saveAuthCredentials: stub()
+      saveAuthCredentials: stub(),
+      ...basicProps
     };
 
     let wrapper = shallow(<Root {...propsWithAuthPlugin} />);
-    expect(plugin.lookForCredentials.callCount).to.equal(1);
+    expect((plugin.lookForCredentials as typeof stub).callCount).to.equal(1);
     expect(propsWithAuthPlugin.saveAuthCredentials.callCount).to.equal(1);
     expect(propsWithAuthPlugin.saveAuthCredentials.args[0][0]).to.deep.equal(
       credentials
@@ -257,11 +373,12 @@ describe("Root", () => {
     let plugin = {
       type: "test",
       lookForCredentials: stub().returns({ error: "error!" }),
-      formComponent: null,
-      buttonComponent: null
+      formComponent: stub(),
+      buttonComponent: stub()
     };
     let propsWithAuthPlugin = {
-      authPlugins: [plugin]
+      authPlugins: [plugin],
+      ...basicProps
     };
 
     let wrapper = shallow(<Root {...propsWithAuthPlugin} />);
@@ -270,7 +387,14 @@ describe("Root", () => {
   });
 
   it("shows error message if there's an auth error in the state", () => {
-    let wrapper = shallow(<Root />);
+    let wrapper = shallow(
+      <Root
+        fulfillBook={fulfillBook}
+        indirectFulfillBook={indirectFulfillBook}
+        updateBook={updateBook}
+        setPreference={setPreference}
+      />
+    );
     wrapper.setState({ authError: "error!" });
     let error = wrapper.find(ErrorMessage);
     expect(error.length).to.equal(1);
@@ -288,6 +412,10 @@ describe("Root", () => {
     let setCollectionAndBook = stub().returns(setCollectionAndBookPromise);
     let wrapper = shallow(
       <Root
+        fulfillBook={fulfillBook}
+        indirectFulfillBook={indirectFulfillBook}
+        updateBook={updateBook}
+        setPreference={setPreference}
         collectionUrl={collectionUrl}
         setCollectionAndBook={setCollectionAndBook}
       />
@@ -302,12 +430,28 @@ describe("Root", () => {
   });
 
   it("shows loading message", () => {
-    let wrapper = shallow(<Root isFetchingCollection={true} />);
+    let wrapper = shallow(
+      <Root
+        fulfillBook={fulfillBook}
+        indirectFulfillBook={indirectFulfillBook}
+        updateBook={updateBook}
+        setPreference={setPreference}
+        isFetchingCollection={true}
+      />
+    );
 
     let loadings = wrapper.find(LoadingIndicator);
     expect(loadings.length).to.equal(1);
 
-    wrapper = shallow(<Root isFetchingBook={true} />);
+    wrapper = shallow(
+      <Root
+        fulfillBook={fulfillBook}
+        indirectFulfillBook={indirectFulfillBook}
+        updateBook={updateBook}
+        setPreference={setPreference}
+        isFetchingBook={true}
+      />
+    );
     loadings = wrapper.find(LoadingIndicator);
     expect(loadings.length).to.equal(1);
   });
@@ -320,7 +464,14 @@ describe("Root", () => {
     };
     let retry = stub();
     let wrapper = shallow(
-      <Root error={fetchError} retryCollectionAndBook={retry} />
+      <Root
+        fulfillBook={fulfillBook}
+        indirectFulfillBook={indirectFulfillBook}
+        updateBook={updateBook}
+        setPreference={setPreference}
+        error={fetchError}
+        retryCollectionAndBook={retry}
+      />
     );
 
     let error = wrapper.find(ErrorMessage);
@@ -344,6 +495,10 @@ describe("Root", () => {
     let closeErrorAndHideAuthForm = stub();
     let wrapper = shallow(
       <Root
+        fulfillBook={fulfillBook}
+        indirectFulfillBook={indirectFulfillBook}
+        updateBook={updateBook}
+        setPreference={setPreference}
         auth={auth}
         saveAuthCredentials={saveAuthCredentials}
         closeErrorAndHideAuthForm={closeErrorAndHideAuthForm}
@@ -390,6 +545,7 @@ describe("Root", () => {
         indirectFulfillBook={indirectFulfillBook}
         isSignedIn={true}
         epubReaderUrlTemplate={epubReaderUrlTemplate}
+        setPreference={setPreference}
       />
     );
 
@@ -420,7 +576,14 @@ describe("Root", () => {
     ];
 
     let wrapper = shallow(
-      <Root collectionData={ungroupedCollectionData} history={history} />
+      <Root
+        fulfillBook={fulfillBook}
+        indirectFulfillBook={indirectFulfillBook}
+        updateBook={updateBook}
+        setPreference={setPreference}
+        collectionData={ungroupedCollectionData}
+        history={history}
+      />
     );
 
     let breadcrumbs = wrapper.find(Breadcrumbs);
@@ -441,6 +604,10 @@ describe("Root", () => {
     let computeBreadcrumbs = data => [breadcrumb];
     let wrapper = shallow(
       <Root
+        fulfillBook={fulfillBook}
+        indirectFulfillBook={indirectFulfillBook}
+        updateBook={updateBook}
+        setPreference={setPreference}
         collectionData={ungroupedCollectionData}
         computeBreadcrumbs={computeBreadcrumbs}
       />
@@ -474,6 +641,8 @@ describe("Root", () => {
           updateBook={updateBook}
           fulfillBook={fulfillBook}
           epubReaderUrlTemplate={epubReaderUrlTemplate}
+          setPreference={setPreference}
+          indirectFulfillBook={indirectFulfillBook}
         />
       );
 
@@ -500,11 +669,15 @@ describe("Root", () => {
       let wrapper = shallow(
         <Root
           bookData={bookData}
-          bookUrl={null}
+          bookUrl={undefined}
           collectionUrl="test collection"
           refreshCollectionAndBook={refresh}
           setCollectionAndBook={mockSetCollectionAndBook}
           BookDetailsContainer={Container}
+          fulfillBook={fulfillBook}
+          indirectFulfillBook={indirectFulfillBook}
+          updateBook={updateBook}
+          setPreference={setPreference}
         />
       );
       let containers = wrapper.find(Container);
@@ -524,6 +697,10 @@ describe("Root", () => {
         collectionData={collectionData}
         bookData={bookData}
         pageTitleTemplate={pageTitleTemplate}
+        fulfillBook={fulfillBook}
+        indirectFulfillBook={indirectFulfillBook}
+        updateBook={updateBook}
+        setPreference={setPreference}
       />
     );
 
@@ -588,6 +765,10 @@ describe("Root", () => {
           clearAuthCredentials={clearAuthCredentials}
           isSignedIn={true}
           loansUrl="loans"
+          fulfillBook={fulfillBook}
+          indirectFulfillBook={indirectFulfillBook}
+          updateBook={updateBook}
+          setPreference={setPreference}
         />
       );
     });
@@ -624,6 +805,10 @@ describe("Root", () => {
           collectionData={collectionData}
           bookData={bookData}
           fetchSearchDescription={(url: string) => {}}
+          fulfillBook={fulfillBook}
+          indirectFulfillBook={indirectFulfillBook}
+          updateBook={updateBook}
+          setPreference={setPreference}
         />
       );
     });
@@ -659,6 +844,10 @@ describe("Root", () => {
           collectionData={collectionData}
           bookData={bookData}
           setCollectionAndBook={mockSetCollectionAndBook}
+          fulfillBook={fulfillBook}
+          indirectFulfillBook={indirectFulfillBook}
+          updateBook={updateBook}
+          setPreference={setPreference}
         />,
         { context }
       ) as any;
@@ -679,6 +868,10 @@ describe("Root", () => {
           collectionData={collectionData}
           bookData={bookData}
           setCollectionAndBook={mockSetCollectionAndBook}
+          fulfillBook={fulfillBook}
+          indirectFulfillBook={indirectFulfillBook}
+          updateBook={updateBook}
+          setPreference={setPreference}
         />,
         { context }
       ) as any;
@@ -715,6 +908,10 @@ describe("Root", () => {
           collectionData={collectionData}
           bookData={bookData}
           setCollectionAndBook={mockSetCollectionAndBook}
+          fulfillBook={fulfillBook}
+          indirectFulfillBook={indirectFulfillBook}
+          updateBook={updateBook}
+          setPreference={setPreference}
         />,
         { context }
       ) as any;
@@ -734,6 +931,10 @@ describe("Root", () => {
           collectionData={collectionData}
           bookData={bookData}
           setCollectionAndBook={mockSetCollectionAndBook}
+          fulfillBook={fulfillBook}
+          indirectFulfillBook={indirectFulfillBook}
+          updateBook={updateBook}
+          setPreference={setPreference}
         />,
         { context }
       ) as any;
@@ -775,8 +976,12 @@ describe("Root", () => {
       wrapper = mount(
         <Root
           collectionData={collectionData}
-          bookData={null}
+          bookData={undefined}
           history={history}
+          fulfillBook={fulfillBook}
+          indirectFulfillBook={indirectFulfillBook}
+          updateBook={updateBook}
+          setPreference={setPreference}
         />,
         { context, childContextTypes }
       ) as any;
@@ -844,6 +1049,10 @@ describe("Root", () => {
             history={history}
             collectionUrl="/test"
             setCollectionAndBook={mockSetCollectionAndBook}
+            fulfillBook={fulfillBook}
+            indirectFulfillBook={indirectFulfillBook}
+            updateBook={updateBook}
+            setPreference={setPreference}
           />
         );
 
@@ -857,6 +1066,10 @@ describe("Root", () => {
             history={history}
             collectionUrl="/test"
             setCollectionAndBook={mockSetCollectionAndBook}
+            fulfillBook={fulfillBook}
+            indirectFulfillBook={indirectFulfillBook}
+            updateBook={updateBook}
+            setPreference={setPreference}
           />
         );
 
@@ -874,6 +1087,10 @@ describe("Root", () => {
             history={history}
             collectionUrl="/test"
             setCollectionAndBook={mockSetCollectionAndBook}
+            fulfillBook={fulfillBook}
+            indirectFulfillBook={indirectFulfillBook}
+            updateBook={updateBook}
+            setPreference={setPreference}
           />
         );
 
@@ -923,6 +1140,10 @@ describe("Root", () => {
           collectionUrl="/test"
           setCollectionAndBook={mockSetCollectionAndBook}
           CollectionContainer={Tabs}
+          fulfillBook={fulfillBook}
+          indirectFulfillBook={indirectFulfillBook}
+          updateBook={updateBook}
+          setPreference={setPreference}
         />
       );
 

--- a/packages/opds-web-client/src/components/__tests__/collectionData.ts
+++ b/packages/opds-web-client/src/components/__tests__/collectionData.ts
@@ -1,3 +1,4 @@
+import { BookData } from "./../../interfaces";
 import { CollectionData } from "../../interfaces";
 
 let groupedCollectionData: CollectionData = {
@@ -78,12 +79,11 @@ let ungroupedCollectionData: CollectionData = Object.assign(
   {},
   groupedCollectionData
 );
-ungroupedCollectionData.books = ungroupedCollectionData.lanes.reduce(
-  (results, lane) => {
-    return results.concat(lane.books);
-  },
-  []
-);
+ungroupedCollectionData.books = ungroupedCollectionData.lanes.reduce<
+  BookData[]
+>((results, lane) => {
+  return results.concat(lane.books);
+}, []);
 ungroupedCollectionData.lanes = [];
 ungroupedCollectionData.url = "http://circulation.librarysimplified.org/lane/";
 

--- a/packages/opds-web-client/src/components/__tests__/mergeRootProps-test.ts
+++ b/packages/opds-web-client/src/components/__tests__/mergeRootProps-test.ts
@@ -35,6 +35,7 @@ describe("findBookInCollection", () => {
   it("finds a book in the collection by url", () => {
     let collection = groupedCollectionData;
     let book = groupedCollectionData.lanes[0].books[0];
+    if (!book.url) throw new Error("Book is missing url");
     let result = findBookInCollection(collection, book.url);
     expect(result).to.equal(book);
   });

--- a/packages/opds-web-client/src/components/context/PathForContext.tsx
+++ b/packages/opds-web-client/src/components/context/PathForContext.tsx
@@ -7,7 +7,9 @@ import * as PropTypes from "prop-types";
  * via both old and new context apis.
  */
 
-export const PathForContext = React.createContext<PathFor>(null);
+export const PathForContext = React.createContext<PathFor | undefined>(
+  undefined
+);
 
 type PathForProps = {
   pathFor: PathFor;

--- a/packages/opds-web-client/src/components/context/RouterContext.tsx
+++ b/packages/opds-web-client/src/components/context/RouterContext.tsx
@@ -11,7 +11,9 @@ import * as PropTypes from "prop-types";
  * compatibility with current opds-web.
  */
 
-export const RouterContext = React.createContext<RouterType>(null);
+export const RouterContext = React.createContext<RouterType | undefined>(
+  undefined
+);
 
 type RouterContextProps = {
   router: RouterType;

--- a/packages/opds-web-client/src/components/context/__tests__/StoreContext-test.tsx
+++ b/packages/opds-web-client/src/components/context/__tests__/StoreContext-test.tsx
@@ -35,8 +35,8 @@ const PathForContext = ({ children }) => {
 
 describe("StoreContext", () => {
   const props = {
-    initialState: null,
-    authPlugins: null
+    initialState: undefined,
+    authPlugins: undefined
   };
 
   class Child extends React.Component {

--- a/packages/opds-web-client/src/components/mergeRootProps.ts
+++ b/packages/opds-web-client/src/components/mergeRootProps.ts
@@ -8,7 +8,10 @@ import {
   AuthCredentials
 } from "../interfaces";
 
-export function findBookInCollection(collection: CollectionData, book: string) {
+export function findBookInCollection(
+  collection: CollectionData | null,
+  book: string
+) {
   if (collection) {
     let allBooks = collection.lanes.reduce((books, lane) => {
       return books.concat(lane.books);
@@ -87,9 +90,12 @@ export function createFetchCollectionAndBook(dispatch) {
   let actions = mapDispatchToProps(dispatch).createDispatchProps(fetcher);
   let { fetchCollection, fetchBook } = actions;
   return (
-    collectionUrl: string,
-    bookUrl: string
-  ): Promise<{ collectionData: CollectionData; bookData: BookData }> => {
+    collectionUrl: string | undefined | null,
+    bookUrl?: string | null
+  ): Promise<{
+    collectionData: CollectionData | null;
+    bookData: BookData | null;
+  }> => {
     return fetchCollectionAndBook({
       fetchCollection,
       fetchBook,
@@ -104,7 +110,10 @@ export function fetchCollectionAndBook({
   fetchBook,
   collectionUrl,
   bookUrl
-}): Promise<{ collectionData: CollectionData; bookData: BookData }> {
+}): Promise<{
+  collectionData: CollectionData | null;
+  bookData: BookData | null;
+}> {
   return new Promise((resolve, reject) => {
     if (collectionUrl) {
       fetchCollection(collectionUrl)
@@ -144,7 +153,7 @@ export function mergeRootProps(
   let dispatchProps = createDispatchProps.createDispatchProps(fetcher);
   let authCredentials = fetcher.getAuthCredentials();
 
-  let setCollection = (url: string) => {
+  let setCollection = (url: string | null) => {
     return new Promise((resolve, reject) => {
       if (url === stateProps.loadedCollectionUrl) {
         // if url is same, do nothing unless there's currently error
@@ -166,18 +175,18 @@ export function mergeRootProps(
   };
 
   let setBook = (
-    book: BookData | string,
-    collectionData: CollectionData = null
+    book: BookData | string | null,
+    collectionData: CollectionData | null = null
   ) => {
     return new Promise((resolve, reject) => {
-      let url = null;
-      let bookData = null;
+      let url: string | null = null;
+      let bookData: BookData | null = null;
 
       if (typeof book === "string") {
         url = book;
-        bookData = findBookInCollection(collectionData, url);
+        bookData = findBookInCollection(collectionData, url) ?? null;
       } else if (book && typeof book === "object") {
-        url = book.url;
+        url = book.url ?? null;
         bookData = book;
       }
 

--- a/packages/opds-web-client/src/interfaces.ts
+++ b/packages/opds-web-client/src/interfaces.ts
@@ -8,6 +8,12 @@ export type OpenAccessLinkType =
   | "application/x-mobipocket-ebook"
   | "application/x-mobi8-ebook";
 
+export type FulfillmentLink = {
+  url: string;
+  type: string;
+  indirectType: string;
+};
+
 export interface BookData {
   id: string;
   title: string;
@@ -25,11 +31,7 @@ export interface BookData {
     type: OpenAccessLinkType;
   }[];
   borrowUrl?: string;
-  fulfillmentLinks?: {
-    url: string;
-    type: string;
-    indirectType: string;
-  }[];
+  fulfillmentLinks?: FulfillmentLink[];
   availability?: {
     status: string;
     since?: string;
@@ -78,10 +80,10 @@ export interface CollectionData {
   facetGroups?: FacetGroupData[];
   search?: SearchData;
   nextPageUrl?: string;
-  catalogRootLink?: LinkData;
+  catalogRootLink?: LinkData | null;
   parentLink?: LinkData | null;
   shelfUrl?: string;
-  links?: LinkData[];
+  links?: LinkData[] | null;
   raw?: any;
 }
 
@@ -125,11 +127,11 @@ export interface StateProps {
 }
 
 export interface PathFor {
-  (collectionUrl?: string, bookUrl?: string): string;
+  (collectionUrl?: string | null, bookUrl?: string | null): string;
 }
 
 export interface FetchErrorData {
-  status: number;
+  status: number | null;
   response: string;
   url: string;
 }

--- a/packages/opds-web-client/src/interfaces.ts
+++ b/packages/opds-web-client/src/interfaces.ts
@@ -177,13 +177,13 @@ export interface AuthMethod {
 
 export interface AuthData {
   showForm: boolean;
-  callback: AuthCallback;
-  cancel: () => void;
-  credentials: AuthCredentials;
-  title: string;
+  callback: AuthCallback | null;
+  cancel: (() => void) | null;
+  credentials: AuthCredentials | null;
+  title: string | null;
   error: string | null;
   attemptedProvider: string | null;
-  providers: AuthProvider<AuthMethod>[];
+  providers: AuthProvider<AuthMethod>[] | null;
 }
 
 export interface BasicAuthMethod extends AuthMethod {

--- a/packages/opds-web-client/src/interfaces.ts
+++ b/packages/opds-web-client/src/interfaces.ts
@@ -192,3 +192,9 @@ export interface BasicAuthMethod extends AuthMethod {
     password: string;
   };
 }
+
+type PickAndRequire<T, K extends keyof T> = { [P in K]-?: NonNullable<T[P]> };
+
+/** Utility to make certain keys of a type required */
+export type RequiredKeys<T, K extends keyof T> = Omit<T, K> &
+  PickAndRequire<T, K>;

--- a/packages/opds-web-client/src/reducers/__tests__/collection-test.ts
+++ b/packages/opds-web-client/src/reducers/__tests__/collection-test.ts
@@ -264,10 +264,10 @@ describe("collection reducer", () => {
     });
 
     let newState = reducer(currentState, action);
-    expect(newState.data.search).to.be.ok;
-    expect(newState.data.search.searchData.description).to.equal("d");
-    expect(newState.data.search.searchData.shortName).to.equal("s");
-    expect(newState.data.search.searchData.template("test")).to.equal(
+    expect(newState.data?.search).to.be.ok;
+    expect(newState.data?.search?.searchData?.description).to.equal("d");
+    expect(newState.data?.search?.searchData?.shortName).to.equal("s");
+    expect(newState.data?.search?.searchData?.template("test")).to.equal(
       "test template"
     );
   });

--- a/packages/opds-web-client/src/reducers/__tests__/history-test.ts
+++ b/packages/opds-web-client/src/reducers/__tests__/history-test.ts
@@ -342,6 +342,9 @@ describe("history reducer", () => {
       id: "test id",
       url: "test url",
       title: "test title",
+      catalogRootLink: {
+        url: "root url"
+      },
       lanes: [],
       books: [],
       navigationLinks: []

--- a/packages/opds-web-client/src/reducers/__tests__/loans-test.ts
+++ b/packages/opds-web-client/src/reducers/__tests__/loans-test.ts
@@ -97,7 +97,7 @@ describe("loans reducer", () => {
       id: "new book id",
       url: "new book url",
       title: "new book title",
-      fulfillmentLinks: [{ url: "url", type: "text/html", indirectType: null }]
+      fulfillmentLinks: [{ url: "url", type: "text/html", indirectType: "" }]
     };
     let action = actions.load<BookData>(ActionCreator.UPDATE_BOOK, newBookData);
     let newState = { ...oldState, books: [loansData.books[0], newBookData] };

--- a/packages/opds-web-client/src/reducers/book.ts
+++ b/packages/opds-web-client/src/reducers/book.ts
@@ -2,10 +2,10 @@ import { BookData, FetchErrorData } from "../interfaces";
 import ActionCreator from "../actions";
 
 export interface BookState {
-  url: string;
-  data: BookData;
+  url: string | null;
+  data: BookData | null;
   isFetching: boolean;
-  error: FetchErrorData;
+  error: FetchErrorData | null;
 }
 
 const initialState: BookState = {

--- a/packages/opds-web-client/src/reducers/collection.ts
+++ b/packages/opds-web-client/src/reducers/collection.ts
@@ -3,8 +3,8 @@ import history from "./history";
 import ActionCreator from "../actions";
 
 export interface CollectionState {
-  url: string;
-  data?: CollectionData;
+  url: string | null;
+  data?: CollectionData | null;
   isFetching?: boolean;
   isFetchingPage: boolean;
   error?: FetchErrorData | null;
@@ -75,7 +75,9 @@ const collection = (state = initialState, action): CollectionState => {
       return {
         ...state,
         data: Object.assign({}, state.data, {
-          books: [...state.data.books].concat(action.data.books),
+          // the following optional chaining will evaluate to [] if
+          // state.data.books is null or undefined
+          books: [...(state.data?.books ?? [])].concat(action.data.books),
           nextPageUrl: action.data.nextPageUrl
         }),
         isFetchingPage: false

--- a/packages/opds-web-client/src/reducers/history.ts
+++ b/packages/opds-web-client/src/reducers/history.ts
@@ -1,3 +1,4 @@
+import { RequiredKeys } from "./../interfaces";
 import { CollectionState } from "./collection";
 import { LoadAction } from "../actions";
 import { CollectionData, LinkData } from "../interfaces";
@@ -28,8 +29,11 @@ function newRootIsNotOldRoot(
   newCollection: CollectionData,
   oldCollection: CollectionData | undefined | null
 ): boolean {
-  return (
-    newCollection?.catalogRootLink?.url !== oldCollection?.catalogRootLink?.url
+  return !!(
+    oldCollection &&
+    newCollection.catalogRootLink &&
+    oldCollection.catalogRootLink &&
+    newCollection.catalogRootLink.url !== oldCollection.catalogRootLink.url
   );
 }
 
@@ -70,17 +74,18 @@ export function shorten(history: LinkData[], newUrl: string) {
     return history;
   }
 }
+type CollectionWithRootLink = RequiredKeys<CollectionData, "catalogRootLink">;
 
-export function shouldAddRoot(newCollection: CollectionData) {
-  return (
-    newCollection.catalogRootLink &&
-    newCollection.catalogRootLink.text &&
+export function shouldAddRoot(
+  newCollection: CollectionData
+): newCollection is CollectionWithRootLink {
+  return !!(
+    newCollection.catalogRootLink?.text &&
     !newCollectionIsNewRoot(newCollection)
   );
 }
 
-export function onlyRoot(newCollection: CollectionData) {
-  if (!newCollection.catalogRootLink) return [];
+export function onlyRoot(newCollection: CollectionWithRootLink) {
   return addLink([], newCollection.catalogRootLink);
 }
 

--- a/packages/opds-web-client/src/reducers/history.ts
+++ b/packages/opds-web-client/src/reducers/history.ts
@@ -15,38 +15,27 @@ function newCollectionIsOldCollection(
 
 function newCollectionIsOldRoot(
   newCollection: CollectionData,
-  oldCollection: CollectionData
+  oldCollection: CollectionData | undefined
 ): boolean {
-  return (
-    oldCollection &&
-    oldCollection.catalogRootLink &&
-    oldCollection.catalogRootLink.url &&
-    oldCollection.catalogRootLink.url === newCollection.url
-  );
+  return oldCollection?.catalogRootLink?.url === newCollection.url;
 }
 
 function newCollectionIsNewRoot(newCollection: CollectionData): boolean {
-  return (
-    newCollection.catalogRootLink &&
-    newCollection.catalogRootLink.url === newCollection.url
-  );
+  return newCollection?.catalogRootLink?.url === newCollection.url;
 }
 
 function newRootIsNotOldRoot(
   newCollection: CollectionData,
-  oldCollection: CollectionData
+  oldCollection: CollectionData | undefined
 ): boolean {
   return (
-    oldCollection &&
-    newCollection.catalogRootLink &&
-    oldCollection.catalogRootLink &&
-    newCollection.catalogRootLink.url !== oldCollection.catalogRootLink.url
+    newCollection?.catalogRootLink?.url !== oldCollection?.catalogRootLink?.url
   );
 }
 
 export function shouldClear(
   newCollection: CollectionData,
-  oldCollection: CollectionData
+  oldCollection: CollectionData | undefined
 ): boolean {
   return (
     newCollectionIsOldRoot(newCollection, oldCollection) ||
@@ -91,6 +80,7 @@ export function shouldAddRoot(newCollection: CollectionData) {
 }
 
 export function onlyRoot(newCollection: CollectionData) {
+  if (!newCollection.catalogRootLink) return [];
   return addLink([], newCollection.catalogRootLink);
 }
 

--- a/packages/opds-web-client/src/reducers/history.ts
+++ b/packages/opds-web-client/src/reducers/history.ts
@@ -15,7 +15,7 @@ function newCollectionIsOldCollection(
 
 function newCollectionIsOldRoot(
   newCollection: CollectionData,
-  oldCollection: CollectionData | undefined
+  oldCollection: CollectionData | undefined | null
 ): boolean {
   return oldCollection?.catalogRootLink?.url === newCollection.url;
 }
@@ -26,7 +26,7 @@ function newCollectionIsNewRoot(newCollection: CollectionData): boolean {
 
 function newRootIsNotOldRoot(
   newCollection: CollectionData,
-  oldCollection: CollectionData | undefined
+  oldCollection: CollectionData | undefined | null
 ): boolean {
   return (
     newCollection?.catalogRootLink?.url !== oldCollection?.catalogRootLink?.url
@@ -35,7 +35,7 @@ function newRootIsNotOldRoot(
 
 export function shouldClear(
   newCollection: CollectionData,
-  oldCollection: CollectionData | undefined
+  oldCollection: CollectionData | undefined | null
 ): boolean {
   return (
     newCollectionIsOldRoot(newCollection, oldCollection) ||

--- a/packages/opds-web-client/src/reducers/loans.ts
+++ b/packages/opds-web-client/src/reducers/loans.ts
@@ -2,7 +2,7 @@ import { BookData } from "../interfaces";
 import ActionCreator from "../actions";
 
 export interface LoansState {
-  url: string;
+  url: string | null;
   books: BookData[];
 }
 
@@ -40,7 +40,7 @@ export default (state: LoansState = initialState, action): LoansState => {
       let isBorrowed =
         updatedBook.fulfillmentLinks && updatedBook.fulfillmentLinks.length > 0;
 
-      let newLoans = [];
+      let newLoans: BookData[] = [];
       // Copy over all the books except the updated one.
       for (let loan of state.books) {
         if (loan.id !== updatedBook.id) {

--- a/packages/opds-web-client/src/store.ts
+++ b/packages/opds-web-client/src/store.ts
@@ -5,7 +5,8 @@ const thunk = require("redux-thunk").default;
 import createAuthMiddleware from "./authMiddleware";
 import AuthPlugin from "./AuthPlugin";
 import { PathFor } from "./interfaces";
-let persistState = null;
+let persistState: any = null;
+
 try {
   const testKey = String(Math.random());
   window.localStorage.setItem(testKey, "test");

--- a/packages/opds-web-client/tsconfig.json
+++ b/packages/opds-web-client/tsconfig.json
@@ -8,7 +8,8 @@
     "rootDir": "src",
     "jsx": "react",
     "types": ["mocha", "node"],
-    "declaration": true
+    "declaration": true,
+    "strictNullChecks": true
   },
   "exclude": ["node_modules", "lib", "dist"],
   "typedocOptions": {


### PR DESCRIPTION
I am requesting that this be merged into my own beta branch, but I want to get everyone's eyes on this first.

This enables typescripts [`strictNullChecks`](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-0.html#--strictnullchecks) flag. The change is illustrated below:
```js
// this used to pass
const something: string = null;
// so typescript wouldn't catch this TypeError. Which is dangerous!
something.toUppercase();

function blah(var: string){...}
// so did this
blah();

// now we have to type things explicitly with null/undefined if we want to allow those types
const something: number = null;
//     ^^^ Error: can't assign null to number

// this is how we would do that instead:
const something: number | null = null;
```
In the end, this means that I had to pop around the repo and explicitly type a bunch of things as unions with `null` and `undefined`. In some cases it was a bit more complex than that, and I had to add new checks to make sure something wasn't undefined or null. 

This should make the code base far more stable. The most common production error of any codebase I've ever worked on is accessing a property on `undefined` or `null`, and this should virtually eliminate that. Plus it will make development easier as it will warn you as you're typing if you're doing something wrong. 

Let me know what you guys think