### PR TITLE
fix server-rendering jsdom code

### DIFF
--- a/packages/opds-web-client/CHANGELOG.md
+++ b/packages/opds-web-client/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### v0.3.7
+
+- Updates to new `jsdom` api in our use of it for server rendering.
+
 ### v0.3.6
 
 - Extracts the logic that was previously in `DownloadButton` into `useDownloadButton` so it can be imported and used by circulation-patron-web.

--- a/packages/opds-web-client/package.json
+++ b/packages/opds-web-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opds-web-client",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "OPDS web client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/packages/opds-web-client/src/OPDSDataAdapter.ts
+++ b/packages/opds-web-client/src/OPDSDataAdapter.ts
@@ -27,7 +27,7 @@ const createDOMPurify = require("dompurify");
 if (typeof window === "undefined") {
   // sanitization needs to work server-side,
   // so we use jsdom to build it a window object
-  const JSDOM = require("jsdom");
+  const { JSDOM } = require("jsdom");
   const jsdom = new JSDOM("<!doctype html><html><body></body></html>", {
     url: "http://localhost",
     FetchExternalResources: false,

--- a/packages/opds-web-client/src/OPDSDataAdapter.ts
+++ b/packages/opds-web-client/src/OPDSDataAdapter.ts
@@ -27,14 +27,16 @@ const createDOMPurify = require("dompurify");
 if (typeof window === "undefined") {
   // sanitization needs to work server-side,
   // so we use jsdom to build it a window object
-  const jsdom = require("jsdom");
-  const window = jsdom.jsdom("", {
-    features: {
-      FetchExternalResources: false, // disables resource loading over HTTP / filesystem
-      ProcessExternalResources: false // do not execute JS within script blocks
-    }
-  }).defaultView;
-  sanitizeHtml = createDOMPurify(window).sanitize;
+  const JSDOM = require("jsdom");
+  const jsdom = new JSDOM("<!doctype html><html><body></body></html>", {
+    url: "http://localhost",
+    FetchExternalResources: false,
+    ProcessExternalResources: false
+  });
+  const { window } = jsdom;
+  const { defaultView } = window;
+
+  sanitizeHtml = createDOMPurify(defaultView).sanitize;
 } else {
   sanitizeHtml = createDOMPurify(window).sanitize;
 }


### PR DESCRIPTION
I upgraded the `jsdom` version in my `useDownloadButton` PR, and updated the code appropriately for testing, but I didn't see this use of `jsdom` for server rendering previously. I've updated it to the new `jsdom` api. Tests didn't catch this because that code block is uncovered (window is always defined in tests via the test `jsdom` env)