### PR TITLE
remove isActive from router

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # opds-web-client
+
 JavaScript OPDS web client
 
 ## Standalone App
+
 OPDS Web Client can be run as a standalone app mounted in a DOM element:
 
 ```javascript
@@ -10,7 +12,7 @@ new OPDSWebClient(config, elementId);
 
 For an example of OPDS Web Client in use as a standalone app, see the [demo server template](https://github.com/NYPL-Simplified/opds-web-client/blob/master/packages/server/views/index.html.ejs) included in this repository.
 
-*NOTE*: The web reader has been taken out of the demo server template for now as it is causing build issues. If you want to install it locally and use it for testing, uncomment line 17 in `/packages/server/index.js`, and install it in the `/packages/server` directory:
+_NOTE_: The web reader has been taken out of the demo server template for now as it is causing build issues. If you want to install it locally and use it for testing, uncomment line 17 in `/packages/server/index.js`, and install it in the `/packages/server` directory:
 
 ```bash
  $ npm install --save nypl-simplified-webpub-viewer
@@ -32,6 +34,7 @@ For an example of OPDS Web Client in use as a standalone app, see the [demo serv
 - `allLanguageSearch`: optional string to specify if searches in the catalog should not use the browser's language header in requests. Default: `false`
 
 ## React Component
+
 The application is also available as a reusable React component:
 
 ```jsx
@@ -44,7 +47,7 @@ ReactDOM.render(
     pageTitleTemplate={this.pageTitleTemplate}
     BookDetailsContainer={BookDetailsContainer}
     Header={Header}
-    />
+  />
 );
 ```
 
@@ -65,7 +68,7 @@ For an example of the application in use as a React component, see [NYPL-Simplif
 
 The OPDSCatalog React component should be rendered within a [React context](https://facebook.github.io/react/docs/context.html) that includes two items:
 
-- `router`: any object that implements the `push`, `createHref`, and `isActive` methods of react-router's [context.router](https://reacttraining.com/react-router/core/api/contextrouter)
+- `router`: any object that implements the `push` and `createHref` methods of react-router's [context.router](https://reacttraining.com/react-router/core/api/contextrouter)
 - `pathFor(collectionUrl: string, bookUrl: string) => string`: a function that accepts a collection URL and book URL and returns a string that will become the web browser's relative URL upon navigating to a new collection or book
 
 ## Accessibility

--- a/packages/opds-web-client/CHANGELOG.md
+++ b/packages/opds-web-client/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### v0.4.1
+
+- Removes the unused `isActive` property from the `router` context.
+
 ### v0.4.0
 
 - Extracts the `getMedium` and `getMediumSVG` methods previously on the `Book` component into external functions so they can be imported and used in `circulation-patron-web`.

--- a/packages/opds-web-client/package-lock.json
+++ b/packages/opds-web-client/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "opds-web-client",
-  "version": "0.3.6",
+  "version": "0.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3750,8 +3750,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3772,14 +3771,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3794,20 +3791,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3924,8 +3918,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3937,7 +3930,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3952,7 +3944,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3960,14 +3951,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3986,7 +3975,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4067,8 +4055,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4080,7 +4067,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4166,8 +4152,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4203,7 +4188,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4223,7 +4207,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4267,14 +4250,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/packages/opds-web-client/package.json
+++ b/packages/opds-web-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opds-web-client",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "OPDS web client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/packages/opds-web-client/src/__mocks__/routing.ts
+++ b/packages/opds-web-client/src/__mocks__/routing.ts
@@ -5,8 +5,7 @@ import * as React from "react";
 export const mockRouter = push => {
   return {
     push,
-    createHref: location => "test href",
-    isActive: (location, onlyActiveOnIndex) => true
+    createHref: location => "test href"
   };
 };
 

--- a/packages/opds-web-client/src/components/__tests__/CatalogLink-test.tsx
+++ b/packages/opds-web-client/src/components/__tests__/CatalogLink-test.tsx
@@ -26,7 +26,6 @@ describe("CatalogLink", () => {
     let requiredRouterKeys = [
       "push",
       "createHref",
-      "isActive",
       "replace",
       "go",
       "goBack",

--- a/packages/opds-web-client/src/interfaces.ts
+++ b/packages/opds-web-client/src/interfaces.ts
@@ -151,10 +151,6 @@ export interface Location {
 export interface Router {
   push: (location: string | Location) => any;
   createHref: (location: string | Location) => string;
-  isActive: (
-    location: string | Location,
-    onlyActiveOnIndex?: boolean
-  ) => boolean;
 }
 
 export interface NavigateContext {


### PR DESCRIPTION
This PR removes the unused `isActive` property from the codebase. I wasn't able to find a way this was being used here or in CPW or CW. I have a corresponding PR to remove references to it from CW, and will be removing references to it from the beta branch of CPW. 

Note that this will be a breaking type change for CW and CPW. It will not make the apps stop working, but it will cause a type error if `isActive` is passed in to the `router` after updating this package. In CW this is solved with a corresponding PR to master. In CPW, this is solved with a commit to the beta branch. If master updates on CPW, however, it will get this type error.

For reference, this is one of the coordination challenges that would be solved by moving to a monorepo. We could strip `isActive` from all three packages at once in a single PR and a single release, instead of having to coordinate between them like this. Just food for thought.