### PR TITLE
change book availability to enum

### DIFF
--- a/packages/opds-web-client/CHANGELOG.md
+++ b/packages/opds-web-client/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### v0.4.3
+
+- add `BookAvailability` enum type and use it to tighten `BookData` interface.
+
 ### v0.4.2
 
 - Update `typeMap` and `MediaType` to add audiobook support.

--- a/packages/opds-web-client/package-lock.json
+++ b/packages/opds-web-client/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "opds-web-client",
-  "version": "0.4.0",
+  "version": "0.4.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/opds-web-client/package-lock.json
+++ b/packages/opds-web-client/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "opds-web-client",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/opds-web-client/package.json
+++ b/packages/opds-web-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opds-web-client",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "OPDS web client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/packages/opds-web-client/src/interfaces.ts
+++ b/packages/opds-web-client/src/interfaces.ts
@@ -25,6 +25,12 @@ export type BookMedium =
   | "http://bib.schema.org/Audiobook"
   | "http://schema.org/EBook"
   | "http://schema.org/Book";
+
+export type BookAvailability =
+  | "available"
+  | "unavailable"
+  | "reserved"
+  | "ready";
 export interface BookData {
   id: string;
   title: string;
@@ -41,7 +47,7 @@ export interface BookData {
   borrowUrl?: string;
   fulfillmentLinks?: FulfillmentLink[];
   availability?: {
-    status: string;
+    status: BookAvailability;
     since?: string;
     until?: string;
   };

--- a/packages/opds-web-client/src/reducers/__tests__/loans-test.ts
+++ b/packages/opds-web-client/src/reducers/__tests__/loans-test.ts
@@ -109,7 +109,7 @@ describe("loans reducer", () => {
 
   it("adds newly reserved book on UPDATE_BOOK_LOAD", () => {
     let oldState = { ...initState, books: loansData.books };
-    let newBookData = {
+    let newBookData: BookData = {
       id: "new book id",
       url: "new book url",
       title: "new book title",


### PR DESCRIPTION
This simply updates the `availability` type on `BookData` based on the following info:

https://github.com/NYPL-Simplified/Simplified/wiki/OPDS-For-Library-Patrons#opdsavailability---describing-resource-availability