### PR TITLE
add streaming media flag

### DIFF
--- a/packages/opds-web-client/CHANGELOG.md
+++ b/packages/opds-web-client/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### v0.4.4
+
+- add `isStreaming` flag to returned object from `useDownloadButton`.
+
 ### v0.4.3
 
 - add `BookAvailability` enum type and use it to tighten `BookData` interface.

--- a/packages/opds-web-client/package-lock.json
+++ b/packages/opds-web-client/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "opds-web-client",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/opds-web-client/package.json
+++ b/packages/opds-web-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opds-web-client",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "OPDS web client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/packages/opds-web-client/src/hooks/useDownloadButton.ts
+++ b/packages/opds-web-client/src/hooks/useDownloadButton.ts
@@ -1,4 +1,3 @@
-import * as React from "react";
 import { MediaLink, FulfillmentLink, MediaType } from "./../interfaces";
 import { useActions } from "../components/context/ActionsContext";
 import download from "../components/download";
@@ -30,6 +29,7 @@ type DownloadDetails = {
   downloadLabel: string;
   mimeType: MediaType;
   fileExtension: string;
+  isStreaming: boolean;
 };
 /**
  * We use typescript function overloads to show that if you pass in a link
@@ -79,15 +79,17 @@ export default function useDownloadButton(
     }
   };
 
+  const isStreaming =
+    isIndirect(link) && link.indirectType === STREAMING_MEDIA_LINK_TYPE;
   const typeName = typeMap[mimeTypeValue]?.name;
-  const downloadLabel =
-    isIndirect(link) && link.indirectType === STREAMING_MEDIA_LINK_TYPE
-      ? "Read Online"
-      : `Download${typeName ? " " + typeName : ""}`;
+  const downloadLabel = isStreaming
+    ? "Read Online"
+    : `Download${typeName ? " " + typeName : ""}`;
 
   return {
     fulfill,
     isIndirect: isIndirect(link),
+    isStreaming,
     downloadLabel,
     mimeType: mimeTypeValue,
     fileExtension


### PR DESCRIPTION
Simply passes a flag from the `useDownloadButton` hook on whether the media is streaming or not.