### PR TITLE
Fix auth 

### DIFF
--- a/packages/opds-web-client/CHANGELOG.md
+++ b/packages/opds-web-client/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ### v0.4.5
 
-- send empty `Authentication` header when no credentials are present to prevent sending of cached credentials.
+- Send empty `Authentication` header when no credentials are present to prevent sending of cached credentials.
+- Add overdrive media type
 
 ### v0.4.4
 

--- a/packages/opds-web-client/CHANGELOG.md
+++ b/packages/opds-web-client/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### v0.4.5
+
+- send empty `Authentication` header when no credentials are present to prevent sending of cached credentials.
+
 ### v0.4.4
 
 - add `isStreaming` flag to returned object from `useDownloadButton`.

--- a/packages/opds-web-client/package-lock.json
+++ b/packages/opds-web-client/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "opds-web-client",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/opds-web-client/package.json
+++ b/packages/opds-web-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opds-web-client",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "description": "OPDS web client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/packages/opds-web-client/src/DataFetcher.ts
+++ b/packages/opds-web-client/src/DataFetcher.ts
@@ -166,9 +166,7 @@ export default class DataFetcher {
     headers["X-Requested-With"] = "XMLHttpRequest";
 
     let credentials = this.getAuthCredentials();
-    if (credentials) {
-      headers["Authorization"] = credentials.credentials;
-    }
+    headers["Authorization"] = credentials?.credentials ?? "";
 
     return headers;
   }

--- a/packages/opds-web-client/src/__tests__/DataFetcher-test.ts
+++ b/packages/opds-web-client/src/__tests__/DataFetcher-test.ts
@@ -30,7 +30,7 @@ describe("DataFetcher", () => {
       expect(fetchArgs[0][0]).to.equal("/test-url");
       expect(fetchArgs[0][1]).to.deep.equal({
         ...options,
-        headers: { "X-Requested-With": "XMLHttpRequest" }
+        headers: { "X-Requested-With": "XMLHttpRequest", Authorization: "" }
       });
     });
 
@@ -48,7 +48,8 @@ describe("DataFetcher", () => {
       expect(fetchArgs[0][1]).to.deep.equal({
         credentials: "same-origin",
         headers: {
-          "X-Requested-With": "XMLHttpRequest"
+          "X-Requested-With": "XMLHttpRequest",
+          Authorization: ""
         },
         ...options
       });


### PR DESCRIPTION
Previously, when someone would log out, we would clear the cookie and then _not_ set an auth header on the subsequent request. This would result in the browser adding out Basic Auth header from its cache, which would result in continued logged-in requests until the user closed the tab/window or otherwise cleared their browser cache. 

To fix this, I made it so we always set an `Authorization` header, but if there are no credentials present we set it to an empty string, which results in a proper `401` response from authenticated endpoints. 