### PR TITLE
Add overdrive media types

### DIFF
--- a/packages/opds-web-client/src/interfaces.ts
+++ b/packages/opds-web-client/src/interfaces.ts
@@ -10,7 +10,9 @@ export type MediaType =
   | "application/x-mobi8-ebook"
   | "application/atom+xml;type=entry;profile=opds-catalog"
   | "text/html;profile=http://librarysimplified.org/terms/profiles/streaming-media"
-  | "application/audiobook+json";
+  | "application/audiobook+json"
+  | "application/vnd.overdrive.circulation.api+json;profile=audiobook"
+  | "application/vnd.overdrive.circulation.api+json;profile=ebook";
 
 export interface MediaLink {
   url: string;

--- a/packages/opds-web-client/src/interfaces.ts
+++ b/packages/opds-web-client/src/interfaces.ts
@@ -1,7 +1,7 @@
 import AuthPlugin from "./AuthPlugin";
 
 // the source of truth for media types is located at:
-// https://github.com/NYPL-Simplified/server_core/blob/master/model/constants.py#L237
+// https://github.com/NYPL-Simplified/server_core/blob/master/model/constants.py
 export type MediaType =
   | "application/epub+zip"
   | "application/kepub+zip"

--- a/packages/opds-web-client/src/interfaces.ts
+++ b/packages/opds-web-client/src/interfaces.ts
@@ -1,5 +1,7 @@
 import AuthPlugin from "./AuthPlugin";
 
+// the source of truth for media types is located at:
+// https://github.com/NYPL-Simplified/server_core/blob/master/model/constants.py#L237
 export type MediaType =
   | "application/epub+zip"
   | "application/kepub+zip"

--- a/packages/opds-web-client/src/utils/file.ts
+++ b/packages/opds-web-client/src/utils/file.ts
@@ -1,13 +1,14 @@
 import { MediaType } from "./../interfaces";
 
-type TypeMap = {
-  [key in MediaType]: {
-    extension: string;
-    name: string;
-  };
-};
-
-export const typeMap: TypeMap = {
+export const typeMap: Record<MediaType, { extension: string; name: string }> = {
+  "application/vnd.overdrive.circulation.api+json;profile=audiobook": {
+    extension: "",
+    name: "Overdrive Audiobook"
+  },
+  "application/vnd.overdrive.circulation.api+json;profile=ebook": {
+    extension: "",
+    name: "Overdrive eBook"
+  },
   "application/epub+zip": {
     extension: ".epub",
     name: "EPUB"


### PR DESCRIPTION
This adds overdrive audiobook and ebook manifests as mediatypes to the `MediaType` enum and the `typeMap`. I also added a link back to the `server_core` file that defines these and is the source of truth.