### PR TITLE
add application/vnd.librarysimplified.web-epub to MediaType

### DIFF
--- a/packages/opds-web-client/CHANGELOG.md
+++ b/packages/opds-web-client/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### v0.4.6
+
+- Add AxisNow media type
+
 ### v0.4.5
 
 - Send empty `Authentication` header when no credentials are present to prevent sending of cached credentials.

--- a/packages/opds-web-client/package.json
+++ b/packages/opds-web-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opds-web-client",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "description": "OPDS web client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/packages/opds-web-client/src/interfaces.ts
+++ b/packages/opds-web-client/src/interfaces.ts
@@ -15,7 +15,8 @@ export type MediaType =
   | "application/audiobook+json"
   | "application/vnd.overdrive.circulation.api+json;profile=audiobook"
   | "application/vnd.overdrive.circulation.api+json;profile=ebook"
-  | "application/vnd.librarysimplified.web-epub";
+  | "application/vnd.librarysimplified.web-epub"
+  | "application/vnd.librarysimplified.axisnow+json";
 
 export interface MediaLink {
   url: string;

--- a/packages/opds-web-client/src/interfaces.ts
+++ b/packages/opds-web-client/src/interfaces.ts
@@ -15,7 +15,6 @@ export type MediaType =
   | "application/audiobook+json"
   | "application/vnd.overdrive.circulation.api+json;profile=audiobook"
   | "application/vnd.overdrive.circulation.api+json;profile=ebook"
-  | "application/vnd.librarysimplified.web-epub"
   | "application/vnd.librarysimplified.axisnow+json";
 
 export interface MediaLink {

--- a/packages/opds-web-client/src/interfaces.ts
+++ b/packages/opds-web-client/src/interfaces.ts
@@ -14,7 +14,8 @@ export type MediaType =
   | "text/html;profile=http://librarysimplified.org/terms/profiles/streaming-media"
   | "application/audiobook+json"
   | "application/vnd.overdrive.circulation.api+json;profile=audiobook"
-  | "application/vnd.overdrive.circulation.api+json;profile=ebook";
+  | "application/vnd.overdrive.circulation.api+json;profile=ebook"
+  | "application/vnd.librarysimplified.web-epub";
 
 export interface MediaLink {
   url: string;

--- a/packages/opds-web-client/src/utils/file.ts
+++ b/packages/opds-web-client/src/utils/file.ts
@@ -13,10 +13,6 @@ export const typeMap: Record<MediaType, { extension: string; name: string }> = {
     extension: ".epub",
     name: "EPUB"
   },
-  "application/vnd.librarysimplified.web-epub": {
-    extension: ".xml",
-    name: "WEB EPUB"
-  },
   "application/vnd.librarysimplified.axisnow+json": {
     extension: ".json",
     name: "AxisNow Document"

--- a/packages/opds-web-client/src/utils/file.ts
+++ b/packages/opds-web-client/src/utils/file.ts
@@ -15,7 +15,7 @@ export const typeMap: Record<MediaType, { extension: string; name: string }> = {
   },
   "application/vnd.librarysimplified.axisnow+json": {
     extension: ".json",
-    name: "AxisNow Document"
+    name: "AxisNow eBook"
   },
   "application/kepub+zip": {
     // got this from here: https://wiki.mobileread.com/wiki/Kepub

--- a/packages/opds-web-client/src/utils/file.ts
+++ b/packages/opds-web-client/src/utils/file.ts
@@ -13,6 +13,14 @@ export const typeMap: Record<MediaType, { extension: string; name: string }> = {
     extension: ".epub",
     name: "EPUB"
   },
+  "application/vnd.librarysimplified.web-epub": {
+    extension: ".xml",
+    name: "WEB EPUB"
+  },
+  "application/vnd.librarysimplified.axisnow+json": {
+    extension: ".json",
+    name: "AxisNow Document"
+  },
   "application/kepub+zip": {
     // got this from here: https://wiki.mobileread.com/wiki/Kepub
     extension: ".kepub.epub",


### PR DESCRIPTION
We will need to use the `application/vnd.librarysimplified.web-epub` and `application/vnd.librarysimplified.axisnow+json` types in `circulation-patron-web` for Exploded EPubs.
