### PR TITLE
Update Download copy to "read online" for AxisNow documents

### DIFF
--- a/packages/opds-web-client/CHANGELOG.md
+++ b/packages/opds-web-client/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### v0.4.7
+
+- Display "Read online" instead of "Download..." in download buttons for AxisNow media type
+
 ### v0.4.6
 
 - Add AxisNow media type

--- a/packages/opds-web-client/package.json
+++ b/packages/opds-web-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opds-web-client",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "description": "OPDS web client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/packages/opds-web-client/src/hooks/__tests__/useDownloadButton-test.ts
+++ b/packages/opds-web-client/src/hooks/__tests__/useDownloadButton-test.ts
@@ -63,6 +63,9 @@ describe("useDownloadButton", () => {
       // also don't test for the one type we need to fix, test that separately
       if (mediaType === "vnd.adobe/adept+xml") return;
 
+      if (mediaType === "application/vnd.librarysimplified.axisnow+json")
+        return;
+
       const link: MediaLink = {
         url: "/media-url",
         type: mediaType as MediaType
@@ -81,7 +84,7 @@ describe("useDownloadButton", () => {
     }
   });
 
-  it("provides currect details for streaming media type", () => {
+  it("provides correct details for streaming media type", () => {
     const link: FulfillmentLink = {
       url: "/media-url",
       type: "application/atom+xml;type=entry;profile=opds-catalog",
@@ -98,6 +101,26 @@ describe("useDownloadButton", () => {
     expect(result.current.isIndirect).to.equal(true);
     expect(result.current.mimeType).to.equal(
       "application/atom+xml;type=entry;profile=opds-catalog"
+    );
+    expect(typeof result.current.fulfill).to.equal("function");
+  });
+
+  it("provides correct details for AxisNow type", () => {
+    const link: FulfillmentLink = {
+      url: "/media-url",
+      type: "application/vnd.librarysimplified.axisnow+json",
+      indirectType: ""
+    };
+
+    const { result } = renderHook(() => useDownloadButton(link, "pdf-title"), {
+      wrapper: makeWrapper().wrapper
+    });
+
+    expect(result.current.downloadLabel).to.equal("Read Online");
+    expect(result.current.fileExtension).to.equal(".json");
+    expect(result.current.isIndirect).to.equal(false);
+    expect(result.current.mimeType).to.equal(
+      "application/vnd.librarysimplified.axisnow+json"
     );
     expect(typeof result.current.fulfill).to.equal("function");
   });

--- a/packages/opds-web-client/src/hooks/useDownloadButton.ts
+++ b/packages/opds-web-client/src/hooks/useDownloadButton.ts
@@ -80,7 +80,9 @@ export default function useDownloadButton(
   };
 
   const isStreaming =
-    isIndirect(link) && link.indirectType === STREAMING_MEDIA_LINK_TYPE;
+    (isIndirect(link) && link.indirectType === STREAMING_MEDIA_LINK_TYPE) ||
+    link.type === "application/vnd.librarysimplified.axisnow+json";
+
   const typeName = typeMap[mimeTypeValue]?.name;
   const downloadLabel = isStreaming
     ? "Read Online"


### PR DESCRIPTION
AxisNow documents (application/vnd.librarysimplified.axisnow+json) will be rendered online within circulation-patron-web in the webpub-viewer so the copy for these types of files should be "Read online" instead of "Download"