### PR TITLE
SAML Auth

### DIFF
--- a/packages/opds-web-client/package-lock.json
+++ b/packages/opds-web-client/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "opds-web-client",
-  "version": "0.4.5",
+  "version": "0.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/opds-web-client/package.json
+++ b/packages/opds-web-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opds-web-client",
-  "version": "0.4.5",
+  "version": "0.5.0",
   "description": "OPDS web client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/packages/opds-web-client/src/actions.ts
+++ b/packages/opds-web-client/src/actions.ts
@@ -307,7 +307,6 @@ export default class ActionCreator {
     attemptedProvider?: string | null
   ) {
     const flattenedProviders = flattenSamlProviders(providers);
-    console.log("SHOW AUTH FORM", flattenedProviders);
     return {
       type: ActionCreator.SHOW_AUTH_FORM,
       callback,

--- a/packages/opds-web-client/src/actions.ts
+++ b/packages/opds-web-client/src/actions.ts
@@ -307,6 +307,7 @@ export default class ActionCreator {
     attemptedProvider?: string | null
   ) {
     const flattenedProviders = flattenSamlProviders(providers);
+    console.log("SHOW AUTH FORM", flattenedProviders);
     return {
       type: ActionCreator.SHOW_AUTH_FORM,
       callback,

--- a/packages/opds-web-client/src/actions.ts
+++ b/packages/opds-web-client/src/actions.ts
@@ -10,6 +10,7 @@ import {
   AuthProvider,
   AuthMethod
 } from "./interfaces";
+import { flattenSamlProviders } from "./utils/auth";
 
 export interface LoadAction<T> {
   type: string;
@@ -305,11 +306,12 @@ export default class ActionCreator {
     error?: string,
     attemptedProvider?: string | null
   ) {
+    const flattenedProviders = flattenSamlProviders(providers);
     return {
       type: ActionCreator.SHOW_AUTH_FORM,
       callback,
       cancel,
-      providers,
+      providers: flattenedProviders,
       title,
       error,
       attemptedProvider

--- a/packages/opds-web-client/src/interfaces.ts
+++ b/packages/opds-web-client/src/interfaces.ts
@@ -210,3 +210,33 @@ export interface BasicAuthMethod extends AuthMethod {
 /** Utility to make keys K of type T both required (defined) and not null */
 export type RequiredKeys<T, K extends keyof T> = Omit<T, K> &
   { [P in K]-?: NonNullable<T[P]> };
+
+export type SamlIdp = {
+  privacy_statement_urls: [];
+  logo_urls: [];
+  display_names: [
+    {
+      language: string;
+      value: string;
+    }
+  ];
+  href: string;
+  descriptions: [
+    {
+      language: string;
+      value: string;
+    }
+  ];
+  rel: "authenticate";
+  information_urls: [];
+};
+/**
+ * The server representation has multiple IDPs nested into the one.
+ * We will flatten that out before placing into redux state.
+ */
+export interface ServerSamlMethod extends AuthMethod {
+  links: [SamlIdp];
+}
+export interface ClientSamlMethod extends AuthMethod {
+  href: string;
+}

--- a/packages/opds-web-client/src/interfaces.ts
+++ b/packages/opds-web-client/src/interfaces.ts
@@ -235,7 +235,7 @@ export type SamlIdp = {
  * We will flatten that out before placing into redux state.
  */
 export interface ServerSamlMethod extends AuthMethod {
-  links: [SamlIdp];
+  links: SamlIdp[];
 }
 export interface ClientSamlMethod extends AuthMethod {
   href: string;

--- a/packages/opds-web-client/src/utils/auth.ts
+++ b/packages/opds-web-client/src/utils/auth.ts
@@ -5,7 +5,7 @@ import {
   ServerSamlMethod
 } from "./../interfaces";
 
-export const SAML_AUTH_ID = "http://librarysimplified.org/authtype/SAML-2.0";
+export const SAML_AUTH_TYPE = "http://librarysimplified.org/authtype/SAML-2.0";
 
 export function generateCredentials(username: string, password: string) {
   const btoaStr = btoa(`${username}:${password}`);
@@ -41,4 +41,4 @@ export const getEnglishValue = (arr: [{ language: string; value: string }]) =>
 export const isServerSamlProvider = (
   provider: AuthProvider<AuthMethod>
 ): provider is AuthProvider<ServerSamlMethod> =>
-  provider.id === SAML_AUTH_ID && "links" in provider.method;
+  provider.id === SAML_AUTH_TYPE && "links" in provider.method;

--- a/packages/opds-web-client/src/utils/auth.ts
+++ b/packages/opds-web-client/src/utils/auth.ts
@@ -1,4 +1,44 @@
+import {
+  AuthProvider,
+  AuthMethod,
+  ClientSamlMethod,
+  ServerSamlMethod
+} from "./../interfaces";
+
+export const SAML_AUTH_ID = "http://librarysimplified.org/authtype/SAML-2.0";
+
 export function generateCredentials(username: string, password: string) {
   const btoaStr = btoa(`${username}:${password}`);
   return `Basic ${btoaStr}`;
 }
+
+export function flattenSamlProviders(providers: AuthProvider<AuthMethod>[]) {
+  return providers.reduce((flattened, provider) => {
+    if (isServerSamlProvider(provider)) {
+      return [...flattened, ...serverToClientSamlProviders(provider)];
+    }
+    return [...flattened, provider];
+  }, []);
+}
+
+function serverToClientSamlProviders(
+  provider: AuthProvider<ServerSamlMethod>
+): AuthProvider<ClientSamlMethod>[] {
+  return provider.method.links.map(idp => ({
+    method: {
+      href: idp.href,
+      type: provider.method.type,
+      description: getEnglishValue(idp.display_names) ?? "Unknown SAML Provider"
+    },
+    id: idp.href,
+    plugin: provider.plugin
+  }));
+}
+
+export const getEnglishValue = (arr: [{ language: string; value: string }]) =>
+  arr.find(item => item.language === "en")?.value;
+
+export const isServerSamlProvider = (
+  provider: AuthProvider<AuthMethod>
+): provider is AuthProvider<ServerSamlMethod> =>
+  provider.id === SAML_AUTH_ID && "links" in provider.method;


### PR DESCRIPTION
This PR adds the ability to handle SAML auth providers to opds-web-client. This also makes it possible to use SAML auth in circulation-patron-web. 

With SAML, the auth document now can contain one SAML provider that has many IdPs within it, each representing a sign in "option" for the end user. I chose to flatten these into a single array of auth providers containing both the SAML providers and any others configured. 