### PR TITLE
Fix url resolve

### DIFF
--- a/packages/opds-web-client/CHANGELOG.md
+++ b/packages/opds-web-client/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - Fix: Use `new URL()` instead of `url.resolve` when parsing OPDS links. `resolve` is legacy and was causing bugs when on `https` but trying to resolve a link with a nested `http` segment.
 
+### v0.5.0
+
+- Add: SAML Auth support.
+
 ### v0.4.7
 
 - Display "Read online" instead of "Download..." in download buttons for AxisNow media type

--- a/packages/opds-web-client/CHANGELOG.md
+++ b/packages/opds-web-client/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### v0.4.6
+
+- Fix: Use `new URL()` instead of `url.resolve` when parsing OPDS links. `resolve` is legacy and was causing bugs when on `https` but trying to resolve a link with a nested `http` segment.
+
 ### v0.4.5
 
 - Send empty `Authentication` header when no credentials are present to prevent sending of cached credentials.

--- a/packages/opds-web-client/package-lock.json
+++ b/packages/opds-web-client/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "opds-web-client",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/opds-web-client/package.json
+++ b/packages/opds-web-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opds-web-client",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "description": "OPDS web client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/packages/opds-web-client/src/OPDSDataAdapter.ts
+++ b/packages/opds-web-client/src/OPDSDataAdapter.ts
@@ -20,7 +20,8 @@ import {
   FacetGroupData,
   SearchData
 } from "./interfaces";
-import { resolve } from "url";
+
+const resolve = (base, relative) => new URL(relative, base).toString();
 
 let sanitizeHtml;
 const createDOMPurify = require("dompurify");

--- a/packages/opds-web-client/src/__tests__/OPDSDataAdaptor-test.ts
+++ b/packages/opds-web-client/src/__tests__/OPDSDataAdaptor-test.ts
@@ -93,10 +93,12 @@ describe("OPDSDataAdapter", () => {
       unparsed: "unparsed data"
     });
 
-    let collection = feedToCollection(acquisitionFeed, "");
+    let collection = feedToCollection(acquisitionFeed, "http://test-url.com");
     expect(collection.books.length).to.equal(0);
     expect(collection.lanes.length).to.equal(1);
-    expect(collection.lanes[0].url).to.equal(collectionLink.href);
+    expect(collection.lanes[0].url).to.equal(
+      `http://test-url.com/${collectionLink.href}`
+    );
     expect(collection.raw).to.equal("unparsed data");
 
     let book = collection.lanes[0].books[0];
@@ -151,12 +153,12 @@ describe("OPDSDataAdapter", () => {
       entries: [linkEntry]
     });
 
-    let collection = feedToCollection(navigationFeed, "");
+    let collection = feedToCollection(navigationFeed, "http://test-url.com");
     expect(collection.navigationLinks.length).to.equal(1);
     let link = collection.navigationLinks[0];
     expect(link.id).to.equal(linkEntry.id);
     expect(link.text).to.equal(linkEntry.title);
-    expect(link.url).to.equal(navigationLink.href);
+    expect(link.url).to.equal(`http://test-url.com/${navigationLink.href}`);
   });
 
   it("extracts facet groups", () => {
@@ -186,7 +188,7 @@ describe("OPDSDataAdapter", () => {
       links: facetLinks
     });
 
-    let collection = feedToCollection(acquisitionFeed, "");
+    let collection = feedToCollection(acquisitionFeed, "http://test-url.com");
     expect(collection.facetGroups?.length).to.equal(2);
 
     let groupA = collection.facetGroups?.[0];
@@ -200,17 +202,17 @@ describe("OPDSDataAdapter", () => {
     let facet1 = groupA?.facets[0];
     expect(facet1?.label).to.equal("title 1");
     expect(facet1?.active).to.be.ok;
-    expect(facet1?.href).to.equal("href1");
+    expect(facet1?.href).to.equal("http://test-url.com/href1");
 
     let facet2 = groupB?.facets[0];
     expect(facet2?.label).to.equal("title 2");
     expect(facet2?.active).not.to.be.ok;
-    expect(facet2?.href).to.equal("href2");
+    expect(facet2?.href).to.equal("http://test-url.com/href2");
 
     let facet3 = groupA?.facets[1];
     expect(facet3?.label).to.equal("title 3");
     expect(facet3?.active).not.to.be.ok;
-    expect(facet3?.href).to.equal("href3");
+    expect(facet3?.href).to.equal("http://test-url.com/href3");
   });
 
   it("extracts search link", () => {
@@ -224,9 +226,11 @@ describe("OPDSDataAdapter", () => {
       links: [searchLink]
     });
 
-    let collection = feedToCollection(navigationFeed, "");
+    let collection = feedToCollection(navigationFeed, "http://test-url.com");
     expect(collection.search).to.be.ok;
-    expect(collection.search?.url).to.equal(searchLink.href);
+    expect(collection.search?.url).to.equal(
+      `http://test-url.com/${searchLink.href}`
+    );
   });
 
   it("extracts next page url", () => {
@@ -241,9 +245,9 @@ describe("OPDSDataAdapter", () => {
       links: [nextLink]
     });
 
-    let collection = feedToCollection(acquisitionFeed, "");
+    let collection = feedToCollection(acquisitionFeed, "http://test-url.com");
     expect(collection.nextPageUrl).to.be.ok;
-    expect(collection.nextPageUrl).to.equal("href");
+    expect(collection.nextPageUrl).to.equal("http://test-url.com/href");
   });
 
   it("extracts shelf url", () => {
@@ -258,7 +262,7 @@ describe("OPDSDataAdapter", () => {
       links: [shelfLink]
     });
 
-    let collection = feedToCollection(acquisitionFeed, "");
+    let collection = feedToCollection(acquisitionFeed, "http://test-url.com");
     expect(collection.shelfUrl).to.equal(shelfLink.href);
   });
 
@@ -278,11 +282,14 @@ describe("OPDSDataAdapter", () => {
       links: [aboutLink, termsLink]
     });
 
-    let collection = feedToCollection(acquisitionFeed, "");
+    let collection = feedToCollection(acquisitionFeed, "http://test-url.com");
     expect(collection.links?.length).to.equal(2);
     let urls = collection.links?.map(link => link.url).sort();
     let types = collection.links?.map(link => link.type).sort();
-    expect(urls).to.deep.equal(["about", "terms"]);
+    expect(urls).to.deep.equal([
+      "http://test-url.com/about",
+      "http://test-url.com/terms"
+    ]);
     expect(types).to.deep.equal(["about", "terms-of-service"]);
   });
 });


### PR DESCRIPTION
We previously used the legacy `resolve` method from node's `url` module in the `OPDSDataAdapter`. This caused certain nested urls to be improperly resolved. This PR updates the adapter to use the new URL module, which properly resolves the urls. 

It has been tested in circulation-patron-web. 