### PR TITLE
fix read online label for atom links

### DIFF
--- a/packages/opds-web-client/CHANGELOG.md
+++ b/packages/opds-web-client/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### v0.5.2
+
+- Fix: Show "Read Online" label for atom media types.
+
 ### v0.5.1
 
 - Fix: Use `new URL()` instead of `url.resolve` when parsing OPDS links. `resolve` is legacy and was causing bugs when on `https` but trying to resolve a link with a nested `http` segment.

--- a/packages/opds-web-client/package-lock.json
+++ b/packages/opds-web-client/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "opds-web-client",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/opds-web-client/package.json
+++ b/packages/opds-web-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opds-web-client",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "OPDS web client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/packages/opds-web-client/src/components/__tests__/DownloadButton-test.tsx
+++ b/packages/opds-web-client/src/components/__tests__/DownloadButton-test.tsx
@@ -120,7 +120,7 @@ describe("DownloadButton", () => {
       ...fulfillmentLink,
       type: "application/atom+xml;type=entry;profile=opds-catalog",
       indirectType:
-        "text/html;profile=http://librarysimplified.org/terms/profiles/streaming-media"
+        'text/html;profile="http://librarysimplified.org/terms/profiles/streaming-media"'
     };
     let downloadButton = providerWrapper(
       <DownloadButton style={style} title="title" link={streamingLink} />
@@ -154,7 +154,8 @@ describe("DownloadButton", () => {
     const indirectLink: FulfillmentLink = {
       type: "application/atom+xml;type=entry;profile=opds-catalog",
       url: "web reader url",
-      indirectType: "some/type"
+      indirectType:
+        'text/html;profile="http://librarysimplified.org/terms/profiles/streaming-media"'
     };
     let downloadButton = providerWrapper(
       <DownloadButton style={style} title="title" link={indirectLink} />

--- a/packages/opds-web-client/src/hooks/__tests__/useDownloadButton-test.ts
+++ b/packages/opds-web-client/src/hooks/__tests__/useDownloadButton-test.ts
@@ -173,7 +173,7 @@ describe("useDownloadButton", () => {
       url: "/indirect-url",
       type: "application/atom+xml;type=entry;profile=opds-catalog",
       indirectType:
-        "text/html;profile=http://librarysimplified.org/terms/profiles/streaming-media"
+        'text/html;profile="http://librarysimplified.org/terms/profiles/streaming-media"'
     };
     const indirectFulfillStub = sinon.stub();
     const dispatchStub = sinon.stub();

--- a/packages/opds-web-client/src/hooks/__tests__/useDownloadButton-test.ts
+++ b/packages/opds-web-client/src/hooks/__tests__/useDownloadButton-test.ts
@@ -6,7 +6,8 @@ import {
   MediaLink,
   MediaType,
   FulfillmentLink,
-  STREAMING_MEDIA_LINK_TYPE
+  ATOM_MEDIA_TYPE,
+  AXIS_NOW_WEBPUB_MEDIA_TYPE
 } from "./../../interfaces";
 import makeWrapper from "../../test-utils/makeWrapper";
 import { typeMap } from "../../utils/file";
@@ -60,8 +61,12 @@ describe("useDownloadButton", () => {
     expect(result.current).to.equal(null);
 
     for (const mediaType in typeMap) {
-      // don't test this for the one indirect media type
-      if (mediaType === STREAMING_MEDIA_LINK_TYPE) return;
+      // don't test this for the read online media types
+      if (
+        mediaType === AXIS_NOW_WEBPUB_MEDIA_TYPE ||
+        mediaType === ATOM_MEDIA_TYPE
+      )
+        return;
       // also don't test for the one type we need to fix, test that separately
       if (mediaType === "vnd.adobe/adept+xml") return;
 
@@ -85,12 +90,12 @@ describe("useDownloadButton", () => {
     }
   });
 
-  it("provides correct details for streaming media type", () => {
+  it("provides correct details for ATOM type", () => {
     const link: FulfillmentLink = {
       url: "/media-url",
       type: "application/atom+xml;type=entry;profile=opds-catalog",
       indirectType:
-        "text/html;profile=http://librarysimplified.org/terms/profiles/streaming-media"
+        'text/html;profile="http://librarysimplified.org/terms/profiles/streaming-media"'
     };
 
     const { result } = renderHook(() => useDownloadButton(link, "pdf-title"), {
@@ -118,7 +123,6 @@ describe("useDownloadButton", () => {
 
     expect(result.current.downloadLabel).to.equal("Read Online");
     expect(result.current.fileExtension).to.equal(".json");
-    expect(result.current.isIndirect).to.equal(false);
     expect(result.current.mimeType).to.equal(
       "application/vnd.librarysimplified.axisnow+json"
     );

--- a/packages/opds-web-client/src/hooks/__tests__/useDownloadButton-test.ts
+++ b/packages/opds-web-client/src/hooks/__tests__/useDownloadButton-test.ts
@@ -1,9 +1,13 @@
-import { STREAMING_MEDIA_LINK_TYPE } from "./../useDownloadButton";
 import { expect } from "chai";
 import * as sinon from "sinon";
 import { renderHook } from "@testing-library/react-hooks";
 import useDownloadButton from "../useDownloadButton";
-import { MediaLink, MediaType, FulfillmentLink } from "./../../interfaces";
+import {
+  MediaLink,
+  MediaType,
+  FulfillmentLink,
+  STREAMING_MEDIA_LINK_TYPE
+} from "./../../interfaces";
 import makeWrapper from "../../test-utils/makeWrapper";
 import { typeMap } from "../../utils/file";
 import * as download from "../../components/download";
@@ -22,7 +26,6 @@ describe("useDownloadButton", () => {
 
     expect(result.current.downloadLabel).to.equal("Download PDF");
     expect(result.current.fileExtension).to.equal(".pdf");
-    expect(result.current.isIndirect).to.equal(false);
     expect(result.current.mimeType).to.equal("application/pdf");
     expect(typeof result.current.fulfill).to.equal("function");
   });
@@ -41,7 +44,6 @@ describe("useDownloadButton", () => {
 
     expect(result.current.downloadLabel).to.equal("Download ACSM");
     expect(result.current.fileExtension).to.equal(".acsm");
-    expect(result.current.isIndirect).to.equal(false);
     expect(result.current.mimeType).to.equal("application/vnd.adobe.adept+xml");
     expect(typeof result.current.fulfill).to.equal("function");
   });
@@ -78,7 +80,6 @@ describe("useDownloadButton", () => {
       expect(result.current?.fileExtension).to.equal(
         typeMap[mediaType].extension
       );
-      expect(result.current?.isIndirect).to.equal(false);
       expect(result.current?.mimeType).to.equal(mediaType);
       expect(typeof result.current?.fulfill).to.equal("function");
     }
@@ -98,7 +99,6 @@ describe("useDownloadButton", () => {
 
     expect(result.current.downloadLabel).to.equal("Read Online");
     expect(result.current.fileExtension).to.equal("");
-    expect(result.current.isIndirect).to.equal(true);
     expect(result.current.mimeType).to.equal(
       "application/atom+xml;type=entry;profile=opds-catalog"
     );

--- a/packages/opds-web-client/src/interfaces.ts
+++ b/packages/opds-web-client/src/interfaces.ts
@@ -1,5 +1,15 @@
 import AuthPlugin from "./AuthPlugin";
 
+export const ATOM_MEDIA_TYPE =
+  'text/html;profile="http://librarysimplified.org/terms/profiles/streaming-media"';
+
+export const AXIS_NOW_WEBPUB_MEDIA_TYPE =
+  "application/vnd.librarysimplified.axisnow+json";
+
+export type ReadOnlineMediaType =
+  | typeof ATOM_MEDIA_TYPE
+  | typeof AXIS_NOW_WEBPUB_MEDIA_TYPE;
+
 // the source of truth for media types is located at:
 // https://github.com/NYPL-Simplified/server_core/blob/master/model/constants.py
 export type MediaType =
@@ -11,11 +21,10 @@ export type MediaType =
   | "application/x-mobipocket-ebook"
   | "application/x-mobi8-ebook"
   | "application/atom+xml;type=entry;profile=opds-catalog"
-  | "text/html;profile=http://librarysimplified.org/terms/profiles/streaming-media"
   | "application/audiobook+json"
   | "application/vnd.overdrive.circulation.api+json;profile=audiobook"
   | "application/vnd.overdrive.circulation.api+json;profile=ebook"
-  | "application/vnd.librarysimplified.axisnow+json";
+  | ReadOnlineMediaType;
 
 export interface MediaLink {
   url: string;

--- a/packages/opds-web-client/src/utils/file.ts
+++ b/packages/opds-web-client/src/utils/file.ts
@@ -46,7 +46,7 @@ export const typeMap: Record<MediaType, { extension: string; name: string }> = {
     extension: "",
     name: "atom"
   },
-  "text/html;profile=http://librarysimplified.org/terms/profiles/streaming-media": {
+  'text/html;profile="http://librarysimplified.org/terms/profiles/streaming-media"': {
     extension: "",
     name: "streaming-media"
   },

--- a/packages/opds-web-client/tslint.json
+++ b/packages/opds-web-client/tslint.json
@@ -15,7 +15,6 @@
     "no-trailing-whitespace": true,
     "no-var-keyword": true,
     "one-line": [true, "check-open-brace", "check-whitespace"],
-    "quotemark": [true, "double"],
     "semicolon": true,
     "triple-equals": [true, "allow-null-check"],
     "typedef-whitespace": [


### PR DESCRIPTION
This PR is to make it so that links with indirect type `text/html;profile="http://librarysimplified.org/terms/profiles/streaming-media"` will show the "Read Online" download label instead of "Download atom", since they lead to the overdrive online viewer. 

I do a bit of refactoring of how streaming/indirect media is handled. I renamed "isStreaming" to "isReadOnline" because that seems more explicit. I also stopped exporting `isIndirect` from `useDownloadButton`, because it wasn't being used and it wasn't actually very accurate. This does mean CPW will need a corresponding PR to match the updating API of `useDownloadButton`.