### PR TITLE
add devtools extension

### DIFF
--- a/packages/opds-web-client/CHANGELOG.md
+++ b/packages/opds-web-client/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### v0.5.2
+
+- Patch: Add redux devtools extension compatibility.
+
 ### v0.5.1
 
 - Fix: Use `new URL()` instead of `url.resolve` when parsing OPDS links. `resolve` is legacy and was causing bugs when on `https` but trying to resolve a link with a nested `http` segment.

--- a/packages/opds-web-client/package-lock.json
+++ b/packages/opds-web-client/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "opds-web-client",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/opds-web-client/package-lock.json
+++ b/packages/opds-web-client/package-lock.json
@@ -8143,6 +8143,11 @@
         "symbol-observable": "^1.2.0"
       }
     },
+    "redux-devtools-extension": {
+      "version": "2.13.8",
+      "resolved": "https://registry.npmjs.org/redux-devtools-extension/-/redux-devtools-extension-2.13.8.tgz",
+      "integrity": "sha512-8qlpooP2QqPtZHQZRhx3x3OP5skEV1py/zUdMY28WNAocbafxdG2tRD1MWE7sp8obGMNYuLWanhhQ7EQvT1FBg=="
+    },
     "redux-localstorage": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/redux-localstorage/-/redux-localstorage-0.4.1.tgz",

--- a/packages/opds-web-client/package.json
+++ b/packages/opds-web-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opds-web-client",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "OPDS web client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/packages/opds-web-client/package.json
+++ b/packages/opds-web-client/package.json
@@ -35,6 +35,7 @@
     "react-redux": "^7.1.0",
     "react-router": "^3.2.0",
     "redux": "4.0.1",
+    "redux-devtools-extension": "^2.13.8",
     "redux-localstorage": "^0.4.1",
     "redux-thunk": "^2.3.0",
     "seedrandom": "^2.4.2",

--- a/packages/opds-web-client/src/store.ts
+++ b/packages/opds-web-client/src/store.ts
@@ -1,4 +1,4 @@
-import { compose, createStore, applyMiddleware, Store } from "redux";
+import { createStore, applyMiddleware, Store } from "redux";
 import reducers from "./reducers/index";
 import { State } from "./state";
 const thunk = require("redux-thunk").default;

--- a/packages/opds-web-client/src/store.ts
+++ b/packages/opds-web-client/src/store.ts
@@ -5,6 +5,8 @@ const thunk = require("redux-thunk").default;
 import createAuthMiddleware from "./authMiddleware";
 import AuthPlugin from "./AuthPlugin";
 import { PathFor } from "./interfaces";
+import { composeWithDevTools } from "redux-devtools-extension";
+
 let persistState: any = null;
 
 try {
@@ -31,5 +33,9 @@ export default function buildStore(
   if (persistState) {
     composeArgs.push(persistState("preferences"));
   }
-  return createStore(reducers, initialState, compose.apply(this, composeArgs));
+  return createStore(
+    reducers,
+    initialState,
+    composeWithDevTools.apply(this, composeArgs)
+  );
 }


### PR DESCRIPTION
This adds the ability for the Redux Devtools browser extension to log actions and store updates.

The extension is here: https://github.com/zalmoxisus/redux-devtools-extension

This shouldn't actually add any code weight to the package. It just checks if the extension is available on the window and calls it if so. The NPM package added is mainly typescript typings. 