### PR TITLE
add isPlatformCompatible

### DIFF
--- a/packages/opds-web-client/CHANGELOG.md
+++ b/packages/opds-web-client/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### v0.5.2
 
-- Add: Add a `isPlatformCompatible` flag to `useDownloadButton` to indicate whether a link is platform compatible.
+- Add: Add a `linkIsPlatformCompatible` util.
 
 ### v0.5.1
 

--- a/packages/opds-web-client/CHANGELOG.md
+++ b/packages/opds-web-client/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### v0.5.2
+
+- Add: Add a `isPlatformCompatible` flag to `useDownloadButton` to indicate whether a link is platform compatible.
+
 ### v0.5.1
 
 - Fix: Use `new URL()` instead of `url.resolve` when parsing OPDS links. `resolve` is legacy and was causing bugs when on `https` but trying to resolve a link with a nested `http` segment.

--- a/packages/opds-web-client/package-lock.json
+++ b/packages/opds-web-client/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "opds-web-client",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/opds-web-client/package.json
+++ b/packages/opds-web-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opds-web-client",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "OPDS web client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/packages/opds-web-client/src/hooks/useDownloadButton.ts
+++ b/packages/opds-web-client/src/hooks/useDownloadButton.ts
@@ -3,9 +3,7 @@ import { useActions } from "../components/context/ActionsContext";
 import download from "../components/download";
 import { generateFilename, typeMap } from "../utils/file";
 
-export function fixMimeType(
-  mimeType: MediaType | "vnd.adobe/adept+xml"
-): MediaType {
+export function fixMimeType(mimeType: MediaType): MediaType {
   return mimeType === "vnd.adobe/adept+xml"
     ? "application/vnd.adobe.adept+xml"
     : mimeType;
@@ -23,12 +21,20 @@ function isIndirect(
 export const STREAMING_MEDIA_LINK_TYPE: MediaType =
   "text/html;profile=http://librarysimplified.org/terms/profiles/streaming-media";
 
+const isMac = navigator.platform.indexOf("Mac") > -1;
+function isPlatformCompatible(link: MediaLink | FulfillmentLink) {
+  if (isMac && fixMimeType(link.type) === "application/vnd.adobe.adept+xml")
+    return false;
+  return true;
+}
+
 type DownloadDetails = {
   fulfill: () => Promise<void>;
   isIndirect: boolean;
   downloadLabel: string;
   mimeType: MediaType;
   fileExtension: string;
+  isPlatformCompatible: boolean;
   isStreaming: boolean;
 };
 /**
@@ -94,6 +100,7 @@ export default function useDownloadButton(
     isStreaming,
     downloadLabel,
     mimeType: mimeTypeValue,
-    fileExtension
+    fileExtension,
+    isPlatformCompatible: isPlatformCompatible(link)
   };
 }

--- a/packages/opds-web-client/src/hooks/useDownloadButton.ts
+++ b/packages/opds-web-client/src/hooks/useDownloadButton.ts
@@ -2,12 +2,7 @@ import { MediaLink, FulfillmentLink, MediaType } from "./../interfaces";
 import { useActions } from "../components/context/ActionsContext";
 import download from "../components/download";
 import { generateFilename, typeMap } from "../utils/file";
-
-export function fixMimeType(mimeType: MediaType): MediaType {
-  return mimeType === "vnd.adobe/adept+xml"
-    ? "application/vnd.adobe.adept+xml"
-    : mimeType;
-}
+import { fixMimeType } from "../utils/book";
 
 function isIndirect(
   link: MediaLink | FulfillmentLink
@@ -21,20 +16,12 @@ function isIndirect(
 export const STREAMING_MEDIA_LINK_TYPE: MediaType =
   "text/html;profile=http://librarysimplified.org/terms/profiles/streaming-media";
 
-const isMac = navigator.platform.indexOf("Mac") > -1;
-function isPlatformCompatible(link: MediaLink | FulfillmentLink) {
-  if (isMac && fixMimeType(link.type) === "application/vnd.adobe.adept+xml")
-    return false;
-  return true;
-}
-
 type DownloadDetails = {
   fulfill: () => Promise<void>;
   isIndirect: boolean;
   downloadLabel: string;
   mimeType: MediaType;
   fileExtension: string;
-  isPlatformCompatible: boolean;
   isStreaming: boolean;
 };
 /**
@@ -100,7 +87,6 @@ export default function useDownloadButton(
     isStreaming,
     downloadLabel,
     mimeType: mimeTypeValue,
-    fileExtension,
-    isPlatformCompatible: isPlatformCompatible(link)
+    fileExtension
   };
 }

--- a/packages/opds-web-client/src/utils/book.tsx
+++ b/packages/opds-web-client/src/utils/book.tsx
@@ -1,5 +1,13 @@
 import * as React from "react";
-import { BookData, LinkData, RequiredKeys, BookMedium } from "../interfaces";
+import {
+  BookData,
+  LinkData,
+  RequiredKeys,
+  BookMedium,
+  MediaLink,
+  FulfillmentLink,
+  MediaType
+} from "../interfaces";
 import { AudioHeadphoneIcon, BookIcon } from "@nypl/dgx-svg-icons";
 
 /**
@@ -30,6 +38,19 @@ export function bookIsBorrowable(
   book: BookData
 ): book is RequiredKeys<BookData, "borrowUrl"> {
   return typeof book.borrowUrl === "string";
+}
+
+export function fixMimeType(mimeType: MediaType): MediaType {
+  return mimeType === "vnd.adobe/adept+xml"
+    ? "application/vnd.adobe.adept+xml"
+    : mimeType;
+}
+
+const isMac = navigator.platform.indexOf("Mac") > -1;
+export function linkIsPlatformCompatible(link: MediaLink | FulfillmentLink) {
+  if (isMac && fixMimeType(link.type) === "application/vnd.adobe.adept+xml")
+    return false;
+  return true;
 }
 
 export function getMedium(book: BookData): BookMedium | "" {


### PR DESCRIPTION
This adds a flag to the return of `useDownloadButton` to indicate whether the file is platform compatible or not. Currently the only check we perform for this is whether the platform is mac and the file type is ACSM. James tells me there is no way to read these files on mac, and so they shouldn't be displayed. 