### PR TITLE
Adds support for multiple borrow links

### DIFF
--- a/packages/opds-web-client/CHANGELOG.md
+++ b/packages/opds-web-client/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### v0.5.3
+
+- Add: BookData interface now has optional allBorrowLinks prop
+
 ### v0.5.2
 
 - Patch: Add redux devtools extension compatibility.

--- a/packages/opds-web-client/package-lock.json
+++ b/packages/opds-web-client/package-lock.json
@@ -3750,7 +3750,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3771,12 +3772,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3791,17 +3794,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3918,7 +3924,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3930,6 +3937,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3944,6 +3952,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3951,12 +3960,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3975,6 +3986,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4055,7 +4067,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4067,6 +4080,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4152,7 +4166,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4188,6 +4203,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4207,6 +4223,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4250,12 +4267,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/packages/opds-web-client/package.json
+++ b/packages/opds-web-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opds-web-client",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "OPDS web client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/packages/opds-web-client/src/DataFetcher.ts
+++ b/packages/opds-web-client/src/DataFetcher.ts
@@ -1,4 +1,3 @@
-import { feedToCollection, entryToBook } from "./OPDSDataAdapter";
 import OPDSParser, { OPDSFeed, OPDSEntry } from "opds-feed-parser";
 import OpenSearchDescriptionParser from "./OpenSearchDescriptionParser";
 import { AuthCredentials } from "./interfaces";

--- a/packages/opds-web-client/src/OPDSDataAdapter.ts
+++ b/packages/opds-web-client/src/OPDSDataAdapter.ts
@@ -18,7 +18,8 @@ import {
   BookData,
   LinkData,
   FacetGroupData,
-  SearchData
+  SearchData,
+  FulfillmentLink
 } from "./interfaces";
 
 const resolve = (base, relative) => new URL(relative, base).toString();
@@ -118,12 +119,26 @@ export function entryToBook(entry: OPDSEntry, feedUrl: string): BookData {
     borrowUrl = resolve(feedUrl, borrowLink.href);
   }
 
-  let allBorrowLinks = <OPDSAcquisitionLink>entry.links.filter(link => {
-    return (
-      link instanceof OPDSAcquisitionLink &&
-      link.rel === OPDSAcquisitionLink.BORROW_REL
-    );
-  });
+  let allBorrowLinks: FulfillmentLink[] = entry.links
+    .filter(link => {
+      return (
+        link instanceof OPDSAcquisitionLink &&
+        link.rel === OPDSAcquisitionLink.BORROW_REL
+      );
+    })
+    .map(link => {
+      let indirectType;
+      let indirects = (link as OPDSAcquisitionLink).indirectAcquisitions;
+
+      if (indirects && indirects.length > 0) {
+        indirectType = indirects[0].type;
+      }
+      return {
+        url: resolve(feedUrl, link.href),
+        type: link.type,
+        indirectType
+      };
+    });
 
   let fulfillmentType;
   let fulfillmentLinks = entry.links

--- a/packages/opds-web-client/src/OPDSDataAdapter.ts
+++ b/packages/opds-web-client/src/OPDSDataAdapter.ts
@@ -118,7 +118,13 @@ export function entryToBook(entry: OPDSEntry, feedUrl: string): BookData {
     borrowUrl = resolve(feedUrl, borrowLink.href);
   }
 
-  let fulfillmentUrls;
+  let allBorrowLinks = <OPDSAcquisitionLink>entry.links.filter(link => {
+    return (
+      link instanceof OPDSAcquisitionLink &&
+      link.rel === OPDSAcquisitionLink.BORROW_REL
+    );
+  });
+
   let fulfillmentType;
   let fulfillmentLinks = entry.links
     .filter(link => {
@@ -134,7 +140,6 @@ export function entryToBook(entry: OPDSEntry, feedUrl: string): BookData {
       if (indirects && indirects.length > 0) {
         indirectType = indirects[0].type;
       }
-
       return {
         url: resolve(feedUrl, link.href),
         type: link.type,
@@ -163,6 +168,7 @@ export function entryToBook(entry: OPDSEntry, feedUrl: string): BookData {
     imageUrl: imageUrl,
     openAccessLinks: openAccessLinks,
     borrowUrl: borrowUrl,
+    allBorrowLinks: allBorrowLinks,
     fulfillmentLinks: fulfillmentLinks,
     availability: availability,
     holds: holds,

--- a/packages/opds-web-client/src/__tests__/OPDSDataAdaptor-test.ts
+++ b/packages/opds-web-client/src/__tests__/OPDSDataAdaptor-test.ts
@@ -102,6 +102,7 @@ describe("OPDSDataAdapter", () => {
     expect(collection.raw).to.equal("unparsed data");
 
     let book = collection.lanes[0].books[0];
+
     expect(book.id).to.equal(entry.id);
     expect(book.title).to.equal(entry.title);
     expect(book.authors?.length).to.equal(2);
@@ -127,6 +128,7 @@ describe("OPDSDataAdapter", () => {
     expect(book.language).to.equal("en");
     expect(book.openAccessLinks?.[0].url).to.equal(openAccessLink.href);
     expect(book.borrowUrl).to.equal(borrowLink.href);
+    expect(book.allBorrowLinks?.[0].url).to.equal(borrowLink.href);
     expect(book.fulfillmentLinks?.[0].url).to.equal(fulfillmentLink.href);
     expect(book.fulfillmentLinks?.[0].type).to.equal(fulfillmentLink.type);
     expect(book.fulfillmentLinks?.[0].indirectType).to.equal(

--- a/packages/opds-web-client/src/interfaces.ts
+++ b/packages/opds-web-client/src/interfaces.ts
@@ -60,6 +60,7 @@ export interface BookData {
   openAccessLinks?: MediaLink[];
   borrowUrl?: string;
   fulfillmentLinks?: FulfillmentLink[];
+  allBorrowLinks?: MediaLink[];
   availability?: {
     status: BookAvailability;
     since?: string;

--- a/packages/opds-web-client/src/interfaces.ts
+++ b/packages/opds-web-client/src/interfaces.ts
@@ -60,7 +60,7 @@ export interface BookData {
   openAccessLinks?: MediaLink[];
   borrowUrl?: string;
   fulfillmentLinks?: FulfillmentLink[];
-  allBorrowLinks?: MediaLink[];
+  allBorrowLinks?: FulfillmentLink[];
   availability?: {
     status: BookAvailability;
     since?: string;


### PR DESCRIPTION
It's possible for a book to have multiple borrow links in an OPDS feed.  This exposes all of those URLs so that they can be used - I made it another entry in `BookData` so that it's not breaking other work, but it's not ideal. 