### PR TITLE
Add LCP support

### DIFF
--- a/packages/opds-web-client/CHANGELOG.md
+++ b/packages/opds-web-client/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### v0.5.7
+
+- Add a button labeled "LCP License" to the UI and allow patrons to download LCP licenses as .lcpl files.
+
 ### v0.5.6
 
 - Fix the `fetchBlob` script to retry on failure if the failure is after a redirect. This is because Amazon S3 will fail if we send it out `Authorization` header.

--- a/packages/opds-web-client/package-lock.json
+++ b/packages/opds-web-client/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "opds-web-client",
-  "version": "0.5.6",
+  "version": "0.5.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/opds-web-client/package.json
+++ b/packages/opds-web-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opds-web-client",
-  "version": "0.5.6",
+  "version": "0.5.7",
   "description": "OPDS web client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/packages/opds-web-client/src/interfaces.ts
+++ b/packages/opds-web-client/src/interfaces.ts
@@ -24,6 +24,7 @@ export type MediaType =
   | "application/audiobook+json"
   | "application/vnd.overdrive.circulation.api+json;profile=audiobook"
   | "application/vnd.overdrive.circulation.api+json;profile=ebook"
+  | "application/vnd.readium.lcp.license.v1.0+json"
   | ReadOnlineMediaType;
 
 export interface MediaLink {

--- a/packages/opds-web-client/src/utils/file.ts
+++ b/packages/opds-web-client/src/utils/file.ts
@@ -53,6 +53,10 @@ export const typeMap: Record<MediaType, { extension: string; name: string }> = {
   "application/audiobook+json": {
     extension: ".audiobook",
     name: "Audiobook"
+  },
+  "application/vnd.readium.lcp.license.v1.0+json": {
+    extension: ".lcpl",
+    name: "LCP license"
   }
 };
 


### PR DESCRIPTION
## Description

<!--- Describe your changes -->

This PR adds support for LCP license files (`application/vnd.readium.lcp.license.v1.0+json`) returned by Circulation Manager during fulfilment of LCP protected books.

Linked PRs:
- [PR # 1194](https://github.com/NYPL-Simplified/server_core/pull/1194) in `core`
- [PR # 1472](https://github.com/NYPL-Simplified/circulation/pull/1472) in `circulation`
- [PR # 125](https://github.com/NYPL-Simplified/circulation-docker/pull/125) in `circulation-docker`