### PR TITLE
Workaround to handle fulfillment redirects to S3

### DIFF
--- a/packages/opds-web-client/CHANGELOG.md
+++ b/packages/opds-web-client/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### v0.5.5
+
+- Fix the `fetchBlob` script to retry on failure if the failure is after a redirect. This is because Amazon S3 will fail if we send it out `Authorization` header.
+
 ### v0.5.4
 
 - Add optional AuthLink to AuthMethod type to support authentication and logo links

--- a/packages/opds-web-client/package-lock.json
+++ b/packages/opds-web-client/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "opds-web-client",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/opds-web-client/package-lock.json
+++ b/packages/opds-web-client/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "opds-web-client",
-  "version": "0.5.2",
+  "version": "0.5.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/opds-web-client/package.json
+++ b/packages/opds-web-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opds-web-client",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "description": "OPDS web client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/packages/opds-web-client/package.json
+++ b/packages/opds-web-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opds-web-client",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "description": "OPDS web client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/packages/opds-web-client/src/DataFetcher.ts
+++ b/packages/opds-web-client/src/DataFetcher.ts
@@ -159,15 +159,17 @@ export default class DataFetcher {
   }
 
   prepareAuthHeaders(headers: any = {}): any {
-    // server needs to know request came from JS in order to omit
-    // 'Www-Authenticate: Basic' header, which triggers browser's
-    // ugly basic auth popup
-    headers["X-Requested-With"] = "XMLHttpRequest";
-
-    let credentials = this.getAuthCredentials();
-    headers["Authorization"] = credentials?.credentials ?? "";
-
-    return headers;
+    const credentials = this.getAuthCredentials();
+    return {
+      Authorization: credentials?.credentials ?? "",
+      // server needs to know request came from JS in order to omit
+      // 'Www-Authenticate: Basic' header, which triggers browser's
+      // ugly basic auth popup
+      "X-Requested-With": "XMLHttpRequest",
+      // if we set an Authorization header already
+      // it should overwrite the one from this function
+      ...headers
+    };
   }
 
   isErrorCode(status: number) {

--- a/packages/opds-web-client/src/__tests__/actions-test.ts
+++ b/packages/opds-web-client/src/__tests__/actions-test.ts
@@ -81,7 +81,7 @@ describe("actions", () => {
         );
         const expectedError = {
           status: 500,
-          response: "Request failed",
+          response: `Response was not okay and was not retried (wasn't the result of a redirect).`,
           url: url
         };
         expect(dispatch.args[1][0].error).to.deep.equal(expectedError);

--- a/packages/opds-web-client/src/actions.ts
+++ b/packages/opds-web-client/src/actions.ts
@@ -83,31 +83,38 @@ export default class ActionCreator {
   }
 
   fetchBlob(type: string, url: string) {
-    return (dispatch): Promise<Blob> => {
+    return async (dispatch): Promise<Blob> => {
       dispatch(this.request(type, url));
-      return new Promise<Blob>((resolve, reject) => {
-        this.fetcher
-          .fetch(url)
-          .then(response => {
-            if (response.ok) {
-              return response.blob();
-            } else {
-              throw {
-                status: response.status,
-                response: "Request failed",
-                url: url
-              };
-            }
-          })
-          .then(blob => {
-            dispatch(this.success(type));
-            resolve(blob);
-          })
-          .catch(err => {
-            dispatch(this.failure(type, err));
-            reject(err);
+      try {
+        const response = await this.fetcher.fetch(url);
+        if (response.ok) return await response.blob();
+        /**
+         * If this the response errored after a redirect, try again
+         * without the Authorization header, as it causes errors when
+         * redirected to Amazon S3
+         */
+        if (response.redirected) {
+          const newResp = await this.fetcher.fetch(response.url, {
+            headers: { Authorization: "" }
           });
-      });
+          const blob = await newResp.blob();
+          if (newResp.ok) {
+            return blob;
+          }
+          console.error("Original Response ", response);
+          console.error("New Response ", newResp);
+          throw new Error(`Retried fetch after redirect did not succeed.`);
+        }
+        console.error("Response: ", response);
+        throw new Error(
+          `Response was not okay and was not retried (wasn't the result of a redirect). Response:\n${JSON.stringify(
+            response
+          )}`
+        );
+      } catch (e) {
+        dispatch(this.failure(type, e));
+        throw e;
+      }
     };
   }
 

--- a/packages/opds-web-client/src/hooks/useDownloadButton.ts
+++ b/packages/opds-web-client/src/hooks/useDownloadButton.ts
@@ -74,11 +74,15 @@ export default function useDownloadButton(
       // OPDS entries
       const action = actions.fulfillBook(link.url);
       const blob = await dispatch(action);
-      download(
-        blob,
-        generateFilename(title ?? "untitled", fileExtension),
-        mimeTypeValue
-      );
+      if (blob)
+        download(
+          blob,
+          generateFilename(title ?? "untitled", fileExtension),
+          mimeTypeValue
+        );
+      else {
+        throw new Error("Fetched book download did not return any content");
+      }
     }
   };
 

--- a/packages/opds-web-client/src/hooks/useDownloadButton.ts
+++ b/packages/opds-web-client/src/hooks/useDownloadButton.ts
@@ -74,15 +74,11 @@ export default function useDownloadButton(
       // OPDS entries
       const action = actions.fulfillBook(link.url);
       const blob = await dispatch(action);
-      if (blob)
-        download(
-          blob,
-          generateFilename(title ?? "untitled", fileExtension),
-          mimeTypeValue
-        );
-      else {
-        throw new Error("Fetched book download did not return any content");
-      }
+      download(
+        blob,
+        generateFilename(title ?? "untitled", fileExtension),
+        mimeTypeValue
+      );
     }
   };
 


### PR DESCRIPTION
This is a fix for a relatively complicated and annoying issue. Basically, when we attempt to download a book, we make an XHR GET request to the CM fulfillment link with our `Authorization` header. The CM then redirects us to wherever the content is ultimately hosted (sometimes through multiple redirects). In the case of DPLA Open Bookshelf, the CM was redirecting ultimately to an S3 bucket. The client would send that url the same request it originally sent to the CM, including the `Authorization` header. S3 did not like that header and would fail with a 400 response. 

To solve this, when a request for a blob fails, I check to see if the failure was after a redirect using `request.redirected`. If it was after a redirect, I retry the fetch without the `Authorization` header. 

### Some things to note:

- Doesn't work in IE (`request.redirected`) is not supported there. To solve this we could have the CM add a `X-Redirect-Url` or similar header in the original redirection. Or we could implement a non-302 redirect pattern, like sending a different status code with the redirect url in the body or another header. 
- The `Authorization` header is still being sent to anyone in the redirect chain. If we want that to stop, we need to implement the above described non-302 redirect pattern.
- I did try to "manually" handle redirects and strip the auth header before making the redirected request, but that is not possible due to browser security. You can either disallow redirects entirely, or follow them transparently. Nothing in between.
- This does introduce some additional latency as we have to wait for the original request to fully follow the redirect chain and then fail before we can detect it is a redirect and try again without the `Authorization` heaader.
- I don't think we control where content is ultimately hosted, so we may run in to more errors like this and need to strip out more headers or change our request in some other way in the future.

Interested to know if anyone else has suggestions here? I presume the mobile clients are following redirects manually and stripping the auth header when following them. It's a pity that isn't possible in the browser.