### PR TITLE
Simply 3869/opds parsing bug fix - TEST

### DIFF
--- a/packages/opds-web-client/CHANGELOG.md
+++ b/packages/opds-web-client/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### v0.6.3-test
 
-- The resolve function in OPDSDataAdapter is causing bugs in the List Manager of CM Admin. This version removed the function in order to test it.
+- The resolve function in OPDSDataAdapter is causing bugs in the List Manager of CM Admin. This version removes the function in order to test it.
 ### v0.6.2
 
 - Updated class `.collection .collection-container` to give more space to the bottom.

--- a/packages/opds-web-client/CHANGELOG.md
+++ b/packages/opds-web-client/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Changelog
 
+### v0.6.3-test
+
+- The resolve function in OPDSDataAdapter is causing bugs in the List Manager of CM Admin. This version removed the function in order to test it.
 ### v0.6.2
 
 - Updated class `.collection .collection-container` to give more space to the bottom.

--- a/packages/opds-web-client/package-lock.json
+++ b/packages/opds-web-client/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "opds-web-client",
-  "version": "0.6.2",
+  "version": "0.6.3-test",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/opds-web-client/package.json
+++ b/packages/opds-web-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opds-web-client",
-  "version": "0.6.2",
+  "version": "0.6.3-test",
   "description": "OPDS web client",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/packages/opds-web-client/src/DataFetcher.ts
+++ b/packages/opds-web-client/src/DataFetcher.ts
@@ -40,6 +40,7 @@ export default class DataFetcher {
 
   fetchOPDSData(url: string) {
     let parser = new OPDSParser();
+    console.log('in fetchOPDSData')
 
     if (!this.adapter) {
       return Promise.reject({

--- a/packages/opds-web-client/src/OPDSDataAdapter.ts
+++ b/packages/opds-web-client/src/OPDSDataAdapter.ts
@@ -21,8 +21,9 @@ import {
   SearchData,
   FulfillmentLink
 } from "./interfaces";
+// import { resolve } from "url";
 
-const resolve = (base, relative) => new URL(relative, base).toString();
+// const resolve = (base, relative) => new URL(relative, base).toString();
 
 let sanitizeHtml;
 const createDOMPurify = require("dompurify");
@@ -65,16 +66,20 @@ export function adapter(
 }
 
 export function entryToBook(entry: OPDSEntry, feedUrl: string): BookData {
+  console.log('in entryToBook function')
   let authors = entry.authors.map(author => {
+    console.log('in authors loop')
     return author.name;
   });
 
   let contributors = entry.contributors.map(contributor => {
+    console.log('in contributors loop')
     return contributor.name;
   });
 
   let imageUrl, imageThumbLink;
   let artworkLinks = entry.links.filter(link => {
+    console.log('in artworkLinks loop')
     return link instanceof OPDSArtworkLink;
   });
   if (artworkLinks.length > 0) {
@@ -82,17 +87,26 @@ export function entryToBook(entry: OPDSEntry, feedUrl: string): BookData {
       link => link.rel === "http://opds-spec.org/image/thumbnail"
     );
     if (imageThumbLink) {
-      imageUrl = resolve(feedUrl, imageThumbLink.href);
+      console.log('in if statement before first resolve in entryToBook')
+      console.log('feedUrl -->', feedUrl)
+      console.log('imageThumLink.href -->', imageThumbLink.href)
+      // imageUrl = resolve(feedUrl, imageThumbLink.href); // feedUrl = /OWL..., imageThumb = https:// --> new URL(https://, /OWL)
+      imageUrl = imageThumbLink.href
     } else {
       console.log("WARNING: using possibly large image for " + entry.title);
-      imageUrl = resolve(feedUrl, artworkLinks[0].href);
+      // imageUrl = resolve(feedUrl, artworkLinks[0].href);
+      imageUrl = artworkLinks[0].href
     }
   }
 
   let detailUrl;
   let detailLink = entry.links.find(link => link instanceof CompleteEntryLink);
   if (detailLink) {
-    detailUrl = resolve(feedUrl, detailLink.href);
+    console.log('in if detailLink statement')
+    console.log('detailLink.href -->', detailLink.href)
+    console.log('feedUrl --->', feedUrl)
+    // detailUrl = resolve(feedUrl, detailLink.href);
+    detailUrl = detailLink.href
   }
 
   let categories = entry.categories
@@ -101,14 +115,18 @@ export function entryToBook(entry: OPDSEntry, feedUrl: string): BookData {
 
   let openAccessLinks = entry.links
     .filter(link => {
+      console.log('in openAccessLinks')
       return (
         link instanceof OPDSAcquisitionLink &&
         link.rel === OPDSAcquisitionLink.OPEN_ACCESS_REL
       );
     })
     .map(link => {
+      console.log('link.href -->', link.href)
+      console.log('feedUrl -->', feedUrl)
       return {
-        url: resolve(feedUrl, link.href),
+        // url: resolve(feedUrl, link.href),
+        url: link.href,
         type: link.type
       };
     });
@@ -121,7 +139,10 @@ export function entryToBook(entry: OPDSEntry, feedUrl: string): BookData {
     );
   });
   if (borrowLink) {
-    borrowUrl = resolve(feedUrl, borrowLink.href);
+    console.log('in borrowLink if statement')
+    console.log('borrowLink.href -->', borrowLink.href)
+    // borrowUrl = resolve(feedUrl, borrowLink.href);
+    borrowUrl = borrowLink.href
   }
 
   let allBorrowLinks: FulfillmentLink[] = entry.links
@@ -139,7 +160,8 @@ export function entryToBook(entry: OPDSEntry, feedUrl: string): BookData {
         indirectType = indirects[0].type;
       }
       return {
-        url: resolve(feedUrl, link.href),
+        // url: resolve(feedUrl, link.href),
+        url: link.href,
         type: link.type,
         indirectType
       };
@@ -161,7 +183,8 @@ export function entryToBook(entry: OPDSEntry, feedUrl: string): BookData {
         indirectType = indirects[0].type;
       }
       return {
-        url: resolve(feedUrl, link.href),
+        url: link.href,
+        // url: resolve(feedUrl, link.href),
         type: link.type,
         indirectType
       };
@@ -205,7 +228,8 @@ export function entryToBook(entry: OPDSEntry, feedUrl: string): BookData {
 function entryToLink(entry: OPDSEntry, feedUrl: string): LinkData | null {
   let links = entry.links;
   if (links.length > 0) {
-    const href = resolve(feedUrl, links[0].href);
+    // const href = resolve(feedUrl, links[0].href);
+    const href = links[0].href
     return {
       id: entry.id,
       text: entry.title,
@@ -258,9 +282,10 @@ function OPDSLinkToLinkData(feedUrl, link: OPDSLink = null): LinkData | null {
   if (!link || !link.href) {
     return null;
   }
-
+console.log('in OPDSLinkToLinkData')  
   return {
-    url: resolve(feedUrl, link.href),
+    // url: resolve(feedUrl, link.href),
+    url: link.href,
     text: link.title,
     type: link.rel
   };
@@ -270,6 +295,7 @@ export function feedToCollection(
   feed: OPDSFeed,
   feedUrl: string
 ): CollectionData {
+  console.log('in feedToCollection function!')
   let collection = <CollectionData>{
     id: feed.id,
     title: feed.title,
@@ -293,20 +319,29 @@ export function feedToCollection(
   let links: OPDSLink[] = [];
 
   feed.entries.forEach(entry => {
+    console.log('in feed.entries loop')
     if (feed instanceof AcquisitionFeed) {
+      console.log('in first if statement')
       let book = entryToBook(entry, feedUrl);
       const collectionLink: OPDSCollectionLink = entry.links.find(
         link => link instanceof OPDSCollectionLink
       );
       if (collectionLink) {
+        console.log('in second if statement')
         let { title, href } = collectionLink;
+        console.log('collectionLink -->', collectionLink)
+        console.log('href from collectionLink --->', href)
 
         if (laneIndex[title]) {
+          console.log('in third if statement')
           laneIndex[title].books.push(book);
         } else {
+          console.log('in else statement')
+          console.log('feedUrl --->', feedUrl)
           laneIndex[title] = {
             title,
-            url: resolve(feedUrl, href),
+            // url: resolve(feedUrl, href),
+            url: href,
             books: [book]
           };
           // use array of titles to preserve lane order
@@ -321,7 +356,10 @@ export function feedToCollection(
     }
   });
 
+  console.log('finished feed.entries loop')
+
   lanes = laneTitles.reduce((result, title) => {
+    console.log('in laneTitles loop')
     let lane = laneIndex[title];
     lane.books = dedupeBooks(lane.books);
     result.push(lane);
@@ -330,6 +368,7 @@ export function feedToCollection(
 
   let facetLinks: OPDSFacetLink[] = [];
   if (feed.links) {
+    console.log('in feed.links if statement')
     facetLinks = feed.links.filter(link => {
       return link instanceof OPDSFacetLink;
     });
@@ -339,17 +378,20 @@ export function feedToCollection(
     });
     if (searchLink) {
       console.log('searchLink is true!')
-      search = { url: resolve(feedUrl, searchLink.href) };
       console.log('feedUrl -->', feedUrl)
       console.log('searchLink.href -->', searchLink.href)
-      console.log('resolved URL -->', resolve(feedUrl, searchLink.href))
+      // search = { url: resolve(feedUrl, searchLink.href) };
+      search = {url: searchLink.href}
     }
 
     let nextPageLink = feed.links.find(link => {
       return link.rel === "next";
     });
     if (nextPageLink) {
-      nextPageUrl = resolve(feedUrl, nextPageLink.href);
+      console.log('in nextPageLink')
+      // nextPageUrl = resolve(feedUrl, nextPageLink.href);
+      nextPageUrl = nextPageLink.href
+      console.log(nextPageUrl)
     }
 
     catalogRootLink = feed.links.find(link => {
@@ -369,7 +411,8 @@ export function feedToCollection(
   facetGroups = facetLinks.reduce((result, link) => {
     let groupLabel = link.facetGroup;
     let label = link.title;
-    let href = resolve(feedUrl, link.href);
+    let href = link.href
+    // let href = resolve(feedUrl, link.href);
     let active = link.activeFacet;
     let facet = { label, href, active };
     let newResult: any[] = [];

--- a/packages/opds-web-client/src/OPDSDataAdapter.ts
+++ b/packages/opds-web-client/src/OPDSDataAdapter.ts
@@ -49,9 +49,14 @@ export function adapter(
   url: string
 ): CollectionData | BookData {
   if (data instanceof OPDSFeed) {
+    console.log('in adapter - OPDSFeed')
+    console.log('url -->', url)
+    console.log('data -->', data) 
     let collectionData = feedToCollection(data, url);
+    console.log('collectionData -->', collectionData)
     return collectionData;
   } else if (data instanceof OPDSEntry) {
+    console.log('in adapter - OPDSEntry')
     let bookData = entryToBook(data, url);
     return bookData;
   } else {
@@ -333,7 +338,11 @@ export function feedToCollection(
       return link instanceof SearchLink;
     });
     if (searchLink) {
+      console.log('searchLink is true!')
       search = { url: resolve(feedUrl, searchLink.href) };
+      console.log('feedUrl -->', feedUrl)
+      console.log('searchLink.href -->', searchLink.href)
+      console.log('resolved URL -->', resolve(feedUrl, searchLink.href))
     }
 
     let nextPageLink = feed.links.find(link => {


### PR DESCRIPTION
The `resolve` function in the `OPDSDataAdapter` file has been causing the CM Admin List Manager's search and edit functionalities to break. I have found that, at least locally, removing the function and its invocations from this file seems to solve the bug, but it needs further testing with more collections. This is why I am making a PR and publishing this potential solution in order to test that it works as expected in QA.